### PR TITLE
Remove bluebird from flow-runtime.

### DIFF
--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -42,7 +42,6 @@
     "babel-traverse": "^6.20.0",
     "babel-types": "^6.16.0",
     "babylon": "^6.14.1",
-    "bluebird": "^3.4.7",
     "camelcase": "^3.0.0",
     "flow-config-parser": "^0.0.5"
   },

--- a/packages/babel-plugin-flow-runtime/src/util.js
+++ b/packages/babel-plugin-flow-runtime/src/util.js
@@ -1,6 +1,20 @@
 /* @flow */
 
 import _fs from 'fs';
-import Bluebird from 'bluebird';
 
-export const fs = Bluebird.promisifyAll(_fs);
+export const fs: Object = Object.keys(_fs).reduce((memo, key) => {
+  memo[`${key}Async`] = promisify(_fs[key]);
+  return memo;
+}, {});
+
+export default function promisify (fn: Function) {
+  return function (...args: Array<any>) {
+    return new Promise(function (resolve, reject) {
+      function callback (err, data) {
+        if (err) return reject(err);
+        resolve(data);
+      }
+      fn(...[...args, callback]);
+    });
+  };
+}


### PR DESCRIPTION
It was used only to load the `.flowconfig` file, and this
also appears to actually be unused by the runtime.

I don't see any code actually loading `loadFlowConfig.js`, is it a future plan for the library?