### PR TITLE
Make type parameters flow compatible

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/boundTypeParameter.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/boundTypeParameter.js
@@ -8,7 +8,7 @@ export const expected = `
   import t from "flow-runtime";
   const demo = input => {
   const T = t.typeParameter("T", t.string());
-    let _inputType = T;
+    let _inputType = t.flowInto(T);
     const _returnType = t.return(T);
     t.param("input", _inputType).assert(input);
     return _returnType.assert(input);
@@ -25,7 +25,7 @@ export const decorated = `
     t.function(_fn => {
       const T = _fn.typeParameter("T", t.string());
       return [
-        t.param("input", T),
+        t.param("input", t.flowInto(T)),
         t.return(T)
       ];
     })
@@ -37,7 +37,7 @@ export const combined = `
   const demo = t.annotate(
     input => {
       const T = t.typeParameter("T", t.string());
-      let _inputType = T;
+      let _inputType = t.flowInto(T);
       const _returnType = t.return(T);
       t.param("input", _inputType).assert(input);
       return _returnType.assert(input);
@@ -45,7 +45,7 @@ export const combined = `
     t.function(_fn => {
       const T = _fn.typeParameter("T", t.string());
       return [
-        t.param("input", T),
+        t.param("input", t.flowInto(T)),
         t.return(T)
       ];
     })

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/multipleTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/multipleTypeParameters.js
@@ -9,8 +9,8 @@ export const expected = `
   const demo = (key, value) => {
     const K = t.typeParameter("K");
     const V = t.typeParameter("V");
-    let _keyType = K;
-    let _valueType = V;
+    let _keyType = t.flowInto(K);
+    let _valueType = t.flowInto(V);
     const _returnType = t.return(t.ref(Map, K, V));
     t.param("key", _keyType).assert(key);
     t.param("value", _valueType).assert(value);

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/nestedFunctionWithTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/nestedFunctionWithTypeParameters.js
@@ -8,7 +8,7 @@ export const expected = `
   import t from "flow-runtime";
   const demo = input => {
     const T = t.typeParameter("T");
-    let _inputType = T;
+    let _inputType = t.flowInto(T);
     const _returnType = t.return(t.function(t.return(T)));
     t.param("input", _inputType).assert(input);
     return _returnType.assert(() => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/simplestFunctionWithTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/simplestFunctionWithTypeParameters.js
@@ -8,7 +8,7 @@ export const expected = `
   import t from "flow-runtime";
   const demo = input => {
     const T = t.typeParameter("T");
-    let _inputType = T;
+    let _inputType = t.flowInto(T);
     const _returnType = t.return(T);
     t.param("input", _inputType).assert(input);
     return _returnType.assert(input);

--- a/packages/flow-runtime-docs/src/compiler.worker.js
+++ b/packages/flow-runtime-docs/src/compiler.worker.js
@@ -3,7 +3,6 @@
 declare var self: DedicatedWorkerGlobalScope;
 
 import {parse} from 'babylon';
-import generate from 'babel-generator';
 import transform from 'babel-plugin-flow-runtime/lib/transform';
 import * as Babel from 'babel-standalone';
 
@@ -31,11 +30,10 @@ function getAST (input: string): AST {
   });
 }
 
-function transformFlowRuntime (ast: AST, options: Object): string {
+function transformFlowRuntime (ast: AST, input: string, options: Object): string {
   transform(ast, options);
-  const {code} = generate(ast, {
-    tabWidth: 2
-  });
+
+  const {code} = Babel.transformFromAst(ast, input, { plugins: ['transform-flow-strip-types']});
   return code;
 }
 
@@ -53,7 +51,7 @@ function compileBabel (ast: AST, input: string): string {
     ast = getAST(input);
     result = [
       id,
-      transformFlowRuntime(ast, options),
+      transformFlowRuntime(ast, input, options),
       compileBabel(ast, input)
     ];
   }

--- a/packages/flow-runtime-docs/src/components/packages/FlowRuntimeValidatorsPage.js
+++ b/packages/flow-runtime-docs/src/components/packages/FlowRuntimeValidatorsPage.js
@@ -11,7 +11,7 @@ const objectExample = `
 import t, {reify} from 'flow-runtime';
 import type {Type} from 'flow-runtime';
 
-import * as validators from 'flow-runtime-validators';
+import * as v from 'flow-runtime-validators';
 
 type User = {
   username: string;
@@ -21,11 +21,11 @@ type User = {
 const UserType = (reify: Type<User>);
 
 UserType.getProperty('username').addConstraint(
-  validators.length({min: 3, max: 16}),
-  validators.regexp({pattern: /^(\\w+)$/, message: 'must be alphanumeric, no spaces.'})
+  v.length({min: 3, max: 16}),
+  v.regexp({pattern: /^(\\w+)$/, message: 'must be alphanumeric, no spaces.'})
 );
 
-UserType.getProperty('email').addConstraint(validators.email());
+UserType.getProperty('email').addConstraint(v.email());
 
 const demoUsers = [
   {username: 'Sally', email: 'sally@example.com'},

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -15,9 +15,6 @@ import makeWarningMessage from './errorReporting/makeWarningMessage';
 import type {PropTypeDict} from './makeReactPropTypes';
 import type {IdentifierPath} from './Validation';
 
-import {openTypeParameters, closeTypeParameters} from './types/TypeParameter';
-
-
 import {
   Type,
   TypeParameter,
@@ -41,6 +38,7 @@ import {
   ObjectTypeCallProperty,
   ObjectTypeIndexer,
   ObjectTypeProperty,
+  FlowIntoType,
   FunctionType,
   ParameterizedFunctionType,
   FunctionTypeParam,
@@ -505,12 +503,10 @@ export default class TypeContext {
     return target;
   }
 
-  openTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
-    openTypeParameters(...typeParameters);
-  }
-
-  closeTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
-    closeTypeParameters(...typeParameters);
+  flowInto <T> (typeParameter: TypeParameter<T>): FlowIntoType<T> {
+    const target = new FlowIntoType(this);
+    target.typeParameter = typeParameter;
+    return target;
   }
 
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {
@@ -906,5 +902,6 @@ export default class TypeContext {
     target.addConstraint(...constraints);
     return target;
   }
+
 }
 

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -15,6 +15,9 @@ import makeWarningMessage from './errorReporting/makeWarningMessage';
 import type {PropTypeDict} from './makeReactPropTypes';
 import type {IdentifierPath} from './Validation';
 
+import {openTypeParameters, closeTypeParameters} from './types/TypeParameter';
+
+
 import {
   Type,
   TypeParameter,
@@ -500,6 +503,14 @@ export default class TypeContext {
     target.id = id;
     target.bound = bound;
     return target;
+  }
+
+  openTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
+    openTypeParameters(...typeParameters);
+  }
+
+  closeTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
+    closeTypeParameters(...typeParameters);
   }
 
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithAnnotatedFunctionArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithAnnotatedFunctionArguments.js
@@ -1,0 +1,62 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  function fn(a) {
+    const T = t.typeParameter("T");
+
+    let _aType = t.function(t.return(t.flowInto(T)));
+
+    const _returnType = t.return(t.array(T));
+
+    t.param("a", _aType).assert(a);
+
+    return _returnType.assert([a(), a()]);
+  }
+
+  let first = true;
+
+  const callback = () => {
+    if (first) {
+      first = false;
+      return true;
+    } else {
+      return 123;
+    }
+  };
+
+  t.annotate(callback, t.function(t.return(t.union(t.boolean(), t.number()))));
+
+  return fn(callback);
+}
+
+
+export function fail (t: TypeContext) {
+  function fn(a) {
+    const T = t.typeParameter("T");
+
+    let _aType = t.function(t.return(t.flowInto(T)));
+
+    const _returnType = t.return(t.array(T));
+
+    t.param("a", _aType).assert(a);
+
+    return _returnType.assert([a(), a(), 'nope']);
+  }
+
+  let first = true;
+
+  const callback = () => {
+    if (first) {
+      first = false;
+      return true;
+    } else {
+      return 123;
+    }
+  };
+
+  t.annotate(callback, t.function(t.return(t.union(t.boolean(), t.number()))));
+
+  return fn(callback);
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithFunctionArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithFunctionArguments.js
@@ -6,32 +6,25 @@ export function pass (t: TypeContext) {
   function fn(a) {
     const T = t.typeParameter("T");
 
-    let _aType = t.function(t.return(T));
+    let _aType = t.function(t.return(t.flowInto(T)));
 
     const _returnType = t.return(t.array(T));
-    t.openTypeParameters(T);
+
     t.param("a", _aType).assert(a);
-    t.closeTypeParameters(T);
+
     return _returnType.assert([a(), a()]);
   }
 
-  let run = false;
-  return fn(() => !run ? (run = true, 123) : 'nope');
-}
+  let first = true;
 
+  const callback = () => {
+    if (first) {
+      first = false;
+      return true;
+    } else {
+      return 123;
+    }
+  };
 
-export function fail (t: TypeContext) {
-  function fn (...args: any[]) {
-    const T = t.typeParameter("T");
-
-    let _argsType = t.array(T);
-
-    const _returnType = t.return(t.array(T));
-    t.openTypeParameters(T);
-    t.rest("args", _argsType).assert(args);
-    t.closeTypeParameters(T);
-    return _returnType.assert([true]);
-  }
-
-  return fn(1, 'yep');
+  return fn(callback);
 }

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithFunctionArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithFunctionArguments.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  function fn(a) {
+    const T = t.typeParameter("T");
+
+    let _aType = t.function(t.return(T));
+
+    const _returnType = t.return(t.array(T));
+    t.openTypeParameters(T);
+    t.param("a", _aType).assert(a);
+    t.closeTypeParameters(T);
+    return _returnType.assert([a(), a()]);
+  }
+
+  let run = false;
+  return fn(() => !run ? (run = true, 123) : 'nope');
+}
+
+
+export function fail (t: TypeContext) {
+  function fn (...args: any[]) {
+    const T = t.typeParameter("T");
+
+    let _argsType = t.array(T);
+
+    const _returnType = t.return(t.array(T));
+    t.openTypeParameters(T);
+    t.rest("args", _argsType).assert(args);
+    t.closeTypeParameters(T);
+    return _returnType.assert([true]);
+  }
+
+  return fn(1, 'yep');
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithTypeParameterArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithTypeParameterArguments.js
@@ -1,0 +1,54 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  const T = t.type('T', T => {
+    const A = T.typeParameter('A');
+    return t.object(
+      t.property('a', A),
+      t.property('b', A)
+    );
+  });
+
+
+  function f(x) {
+    const A = t.typeParameter('A');
+    const _returnType = t.return(A);
+
+    t.openTypeParameters(A);
+    let _xType = t.ref(T, A);
+    t.param('x', _xType).assert(x);
+    t.closeTypeParameters(A);
+
+    return _returnType.assert(x.a);
+  }
+
+  return f({ a: 1, b: 's' }); // <= A is number | string
+}
+
+
+export function fail (t: TypeContext) {
+  const T = t.type('T', T => {
+    const A = T.typeParameter('A');
+    return t.object(
+      t.property('a', A),
+      t.property('b', A)
+    );
+  });
+
+
+  function f(x) {
+    const A = t.typeParameter('A');
+    const _returnType = t.return(A);
+
+    t.openTypeParameters(A);
+    let _xType = t.ref(T, A);
+    t.param('x', _xType).assert(x);
+    t.closeTypeParameters(A);
+
+    return _returnType.assert(false);
+  }
+
+  return f({ a: 1, b: 's' }); // <= A is number | string
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithTypeParameterArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithTypeParameterArguments.js
@@ -16,10 +16,8 @@ export function pass (t: TypeContext) {
     const A = t.typeParameter('A');
     const _returnType = t.return(A);
 
-    t.openTypeParameters(A);
-    let _xType = t.ref(T, A);
+    let _xType = t.ref(T, t.flowInto(A));
     t.param('x', _xType).assert(x);
-    t.closeTypeParameters(A);
 
     return _returnType.assert(x.a);
   }
@@ -42,10 +40,8 @@ export function fail (t: TypeContext) {
     const A = t.typeParameter('A');
     const _returnType = t.return(A);
 
-    t.openTypeParameters(A);
-    let _xType = t.ref(T, A);
+    let _xType = t.ref(T, t.flowInto(A));
     t.param('x', _xType).assert(x);
-    t.closeTypeParameters(A);
 
     return _returnType.assert(false);
   }

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithUnionArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithUnionArguments.js
@@ -6,12 +6,10 @@ export function pass (t: TypeContext) {
   function fn (...args: any[]) {
     const T = t.typeParameter("T");
 
-    let _argsType = t.array(T);
+    let _argsType = t.array(t.flowInto(T));
 
     const _returnType = t.return(t.array(T));
-    t.openTypeParameters(T);
     t.rest("args", _argsType).assert(args);
-    t.closeTypeParameters(T);
     return _returnType.assert(args);
   }
 
@@ -23,12 +21,10 @@ export function fail (t: TypeContext) {
   function fn (...args: any[]) {
     const T = t.typeParameter("T");
 
-    let _argsType = t.array(T);
+    let _argsType = t.array(t.flowInto(T));
 
     const _returnType = t.return(t.array(T));
-    t.openTypeParameters(T);
     t.rest("args", _argsType).assert(args);
-    t.closeTypeParameters(T);
     return _returnType.assert([true]);
   }
 

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithUnionArguments.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ParameterizedFunctionType/typeParametersWithUnionArguments.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  function fn (...args: any[]) {
+    const T = t.typeParameter("T");
+
+    let _argsType = t.array(T);
+
+    const _returnType = t.return(t.array(T));
+    t.openTypeParameters(T);
+    t.rest("args", _argsType).assert(args);
+    t.closeTypeParameters(T);
+    return _returnType.assert(args);
+  }
+
+  return fn(1, true, 'yep');
+}
+
+
+export function fail (t: TypeContext) {
+  function fn (...args: any[]) {
+    const T = t.typeParameter("T");
+
+    let _argsType = t.array(T);
+
+    const _returnType = t.return(t.array(T));
+    t.openTypeParameters(T);
+    t.rest("args", _argsType).assert(args);
+    t.closeTypeParameters(T);
+    return _returnType.assert([true]);
+  }
+
+  return fn(1, 'yep');
+}

--- a/packages/flow-runtime/src/__tests__/fixtures.js
+++ b/packages/flow-runtime/src/__tests__/fixtures.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+import fs from 'fs';
+import path from 'path';
+
+import type TypeContext from '../TypeContext';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+
+const INCLUDE_PATTERN = process.env.TEST_FILTER
+                   ? new RegExp(process.env.TEST_FILTER)
+                   : null
+                   ;
+
+function findFiles (dirname: string, filenames: string[]): string[] {
+  for (const filename of fs.readdirSync(dirname)) {
+    const qualified = path.join(dirname, filename);
+    if (/\.js$/.test(filename)) {
+      filenames.push(qualified.slice(fixturesDir.length + 1, -3));
+    }
+    else {
+      const stat = fs.statSync(qualified);
+      if (stat.isDirectory()) {
+        findFiles(qualified, filenames);
+      }
+    }
+  }
+  return filenames;
+}
+
+function filterIncluded (filename: string): boolean {
+  if (INCLUDE_PATTERN) {
+    return INCLUDE_PATTERN.test(filename);
+  }
+  else {
+    return true;
+  }
+}
+
+const files = findFiles(fixturesDir, []);
+
+export type Fixture = {
+  pass?: (t: TypeContext) => any;
+  fail?: (t: TypeContext) => any;
+};
+
+const fixtures: Map<string, Fixture> = new Map(files.filter(filterIncluded).map(filename => {
+  // @flowIgnore
+  return [filename, require(`./__fixtures__/${filename}`)];
+}));
+
+export default fixtures;

--- a/packages/flow-runtime/src/__tests__/fixtures.test.js
+++ b/packages/flow-runtime/src/__tests__/fixtures.test.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import {ok, throws} from 'assert';
+
+import fixtures from './fixtures';
+
+import t from '../globalContext';
+
+describe.only('fixtures', () => {
+  for (const [name, {pass, fail}] of fixtures) {
+    const context = t.createContext();
+    if (pass) {
+      it(`fixture: ${name} should pass`, () => {
+        ok(pass(context));
+      });
+    }
+    if (fail) {
+      it(`fixture: ${name} should fail`, () => {
+        throws(() => fail(context));
+      });
+    }
+  }
+});

--- a/packages/flow-runtime/src/__tests__/fixtures.test.js
+++ b/packages/flow-runtime/src/__tests__/fixtures.test.js
@@ -6,7 +6,7 @@ import fixtures from './fixtures';
 
 import t from '../globalContext';
 
-describe.only('fixtures', () => {
+describe('fixtures', () => {
   for (const [name, {pass, fail}] of fixtures) {
     const context = t.createContext();
     if (pass) {

--- a/packages/flow-runtime/src/symbols.js
+++ b/packages/flow-runtime/src/symbols.js
@@ -10,4 +10,5 @@ export const TraverseValueSymbol = Symbol('TraverseValue');
 export const TraverseTypeSymbol = Symbol('TraverseType');
 export const TypeSymbol = Symbol('Type');
 export const TypeParametersSymbol = Symbol('TypeParameters');
+export const TypeParameterStatusSymbol = Symbol('TypeParameterStatus');
 export const TypePredicateRegistrySymbol = Symbol('TypePredicateRegistry');

--- a/packages/flow-runtime/src/typed.test.js
+++ b/packages/flow-runtime/src/typed.test.js
@@ -135,7 +135,7 @@ describe('Typed API', () => {
     const bad = () => undefined;
     ok(type.accepts(good));
     ok(type.accepts(better));
-    no(type.accepts(bad));
+    ok(type.accepts(bad)); // not enough type information to reject.
   });
 
   it('should make a parameterized function type', () => {
@@ -159,7 +159,7 @@ describe('Typed API', () => {
     }
     ok(type.accepts(good));
     ok(type.accepts(better));
-    no(type.accepts(bad));
+    ok(type.accepts(bad)); // not enough type information to reject.
   });
 
   it('should build a tree-like object', () => {

--- a/packages/flow-runtime/src/types/FlowIntoType.js
+++ b/packages/flow-runtime/src/types/FlowIntoType.js
@@ -1,0 +1,147 @@
+/* @flow */
+
+import Type from './Type';
+import type Validation, {IdentifierPath} from '../Validation';
+
+import TypeParameter from './TypeParameter';
+
+/**
+ * # FlowIntoType
+ *
+ * A virtual type which allows types it receives to "flow" upwards into a type parameter.
+ * The type parameter will become of a union of any types seen by this instance.
+ */
+export default class FlowIntoType<T> extends Type {
+  typeName: string = 'FlowIntoType';
+
+  typeParameter: TypeParameter<T>;
+
+  collectErrors (validation: Validation<any>, path: IdentifierPath, input: any): boolean {
+    const {typeParameter, context} = this;
+
+    const {recorded, bound} = typeParameter;
+
+    if (bound instanceof FlowIntoType) {
+      // We defer to the other type so that values from this
+      // one can flow "upwards".
+      return bound.collectErrors(validation, path, input);
+    }
+    if (recorded) {
+      // we've already recorded a value for this type parameter
+      if (bound && bound.collectErrors(validation, path, input)) {
+        return true;
+      }
+      else if (recorded.accepts(input)) {
+        // our existing type already permits this value, there's nothing to do.
+        return false;
+      }
+      else {
+        // we need to make a union
+        typeParameter.recorded = context.union(recorded, context.typeOf(input));
+        return false;
+      }
+    }
+    else if (bound) {
+      if (bound.typeName === 'AnyType' || bound.typeName === 'ExistentialType') {
+        return false;
+      }
+      else if (bound.collectErrors(validation, path, input)) {
+        return true;
+      }
+    }
+
+    typeParameter.recorded = context.typeOf(input);
+    return false;
+  }
+
+  accepts (input: any): boolean {
+    const {typeParameter, context} = this;
+
+    const {recorded, bound} = typeParameter;
+
+    if (bound instanceof FlowIntoType) {
+      // We defer to the other type so that values from this
+      // one can flow "upwards".
+      return bound.accepts(input);
+    }
+    if (recorded) {
+      // we've already recorded a value for this type parameter
+      if (bound && !bound.accepts(input)) {
+        return false;
+      }
+      else if (recorded.accepts(input)) {
+        // our existing type already permits this value, there's nothing to do.
+        return true;
+      }
+      else {
+        // we need to make a union
+        typeParameter.recorded = context.union(recorded, context.typeOf(input));
+        return true;
+      }
+    }
+    else if (bound) {
+      if (bound.typeName === 'AnyType' || bound.typeName === 'ExistentialType') {
+        return true;
+      }
+      else if (!bound.accepts(input)) {
+        return false;
+      }
+    }
+
+    typeParameter.recorded = context.typeOf(input);
+    return true;
+  }
+
+  acceptsType (input: Type<any>): boolean {
+    const {typeParameter, context} = this;
+
+    const {recorded, bound} = typeParameter;
+
+    if (bound instanceof FlowIntoType) {
+      // We defer to the other type so that values from this
+      // one can flow "upwards".
+      return bound.acceptsType(input);
+    }
+    if (recorded) {
+      // we've already recorded a value for this type parameter
+      if (bound && !bound.acceptsType(input)) {
+        return false;
+      }
+      else if (recorded.acceptsType(input)) {
+        // our existing type already permits this value, there's nothing to do.
+        return true;
+      }
+      else {
+        // we need to make a union
+        typeParameter.recorded = context.union(recorded, input);
+        return true;
+      }
+    }
+    else if (bound) {
+      if (bound.typeName === 'AnyType' || bound.typeName === 'ExistentialType') {
+        return true;
+      }
+      else if (!bound.acceptsType(input)) {
+        return false;
+      }
+    }
+
+    typeParameter.recorded = input;
+    return true;
+  }
+
+  /**
+   * Get the inner type or value.
+   */
+  unwrap (): Type<T> {
+    return this.typeParameter.unwrap();
+  }
+
+  toString (withBinding?: boolean): string {
+    return this.typeParameter.toString(withBinding);
+  }
+
+  toJSON () {
+    return this.typeParameter.toJSON();
+  }
+}

--- a/packages/flow-runtime/src/types/ParameterizedFunctionType.js
+++ b/packages/flow-runtime/src/types/ParameterizedFunctionType.js
@@ -92,9 +92,7 @@ function getPartial <X, P, R> (parent: ParameterizedFunctionType<X, P, R>, ...ty
 
   const {context, bodyCreator} = parent;
   const partial = new PartialType(context);
-  partial.openTypeParameters();
   const body = bodyCreator(partial);
-  partial.closeTypeParameters(); // this may have already beeen done in the bodyCreator, but make sure.
   partial.type = context.function(...body);
 
   const {typeParameters} = partial;

--- a/packages/flow-runtime/src/types/ParameterizedFunctionType.js
+++ b/packages/flow-runtime/src/types/ParameterizedFunctionType.js
@@ -92,7 +92,9 @@ function getPartial <X, P, R> (parent: ParameterizedFunctionType<X, P, R>, ...ty
 
   const {context, bodyCreator} = parent;
   const partial = new PartialType(context);
+  partial.openTypeParameters();
   const body = bodyCreator(partial);
+  partial.closeTypeParameters(); // this may have already beeen done in the bodyCreator, but make sure.
   partial.type = context.function(...body);
 
   const {typeParameters} = partial;

--- a/packages/flow-runtime/src/types/PartialType.js
+++ b/packages/flow-runtime/src/types/PartialType.js
@@ -3,14 +3,10 @@ import Type from './Type';
 import type {TypeConstraint} from './';
 import type Validation, {IdentifierPath} from '../Validation';
 
-import TypeParameter, {openTypeParameters, closeTypeParameters} from './TypeParameter';
-import type {TypeParameterStatus} from './TypeParameter';
+import TypeParameter from './TypeParameter';
 import TypeParameterApplication from './TypeParameterApplication';
 
 import {collectConstraintErrors, constraintsAccept} from '../typeConstraints';
-
-import {TypeParameterStatusSymbol} from '../symbols';
-
 
 export default class PartialType<X, T> extends Type {
   typeName: string = 'PartialType';
@@ -19,31 +15,12 @@ export default class PartialType<X, T> extends Type {
   typeParameters: TypeParameter<X>[] = [];
   constraints: ? TypeConstraint[];
 
-  [TypeParameterStatusSymbol]: TypeParameterStatus = 'closed';
-
   typeParameter (id: string, bound?: Type<X>): TypeParameter<X> {
     const target = new TypeParameter(this.context);
     target.id = id;
     target.bound = bound;
-    target[TypeParameterStatusSymbol] = this[TypeParameterStatusSymbol];
     this.typeParameters.push(target);
     return target;
-  }
-
-  openTypeParameters () {
-    if (this[TypeParameterStatusSymbol] !== 'open') {
-      const {typeParameters} = this;
-      openTypeParameters(...typeParameters);
-      this[TypeParameterStatusSymbol] = 'open';
-    }
-  }
-
-  closeTypeParameters () {
-    if (this[TypeParameterStatusSymbol] !== 'closed') {
-      const {typeParameters} = this;
-      closeTypeParameters(...typeParameters);
-      this[TypeParameterStatusSymbol] = 'closed';
-    }
   }
 
   apply (...typeInstances: Type<X>[]): TypeParameterApplication<X, T> {

--- a/packages/flow-runtime/src/types/PartialType.js
+++ b/packages/flow-runtime/src/types/PartialType.js
@@ -3,10 +3,13 @@ import Type from './Type';
 import type {TypeConstraint} from './';
 import type Validation, {IdentifierPath} from '../Validation';
 
-import TypeParameter from './TypeParameter';
+import TypeParameter, {openTypeParameters, closeTypeParameters} from './TypeParameter';
+import type {TypeParameterStatus} from './TypeParameter';
 import TypeParameterApplication from './TypeParameterApplication';
 
 import {collectConstraintErrors, constraintsAccept} from '../typeConstraints';
+
+import {TypeParameterStatusSymbol} from '../symbols';
 
 
 export default class PartialType<X, T> extends Type {
@@ -16,12 +19,31 @@ export default class PartialType<X, T> extends Type {
   typeParameters: TypeParameter<X>[] = [];
   constraints: ? TypeConstraint[];
 
+  [TypeParameterStatusSymbol]: TypeParameterStatus = 'closed';
+
   typeParameter (id: string, bound?: Type<X>): TypeParameter<X> {
     const target = new TypeParameter(this.context);
     target.id = id;
     target.bound = bound;
+    target[TypeParameterStatusSymbol] = this[TypeParameterStatusSymbol];
     this.typeParameters.push(target);
     return target;
+  }
+
+  openTypeParameters () {
+    if (this[TypeParameterStatusSymbol] !== 'open') {
+      const {typeParameters} = this;
+      openTypeParameters(...typeParameters);
+      this[TypeParameterStatusSymbol] = 'open';
+    }
+  }
+
+  closeTypeParameters () {
+    if (this[TypeParameterStatusSymbol] !== 'closed') {
+      const {typeParameters} = this;
+      closeTypeParameters(...typeParameters);
+      this[TypeParameterStatusSymbol] = 'closed';
+    }
   }
 
   apply (...typeInstances: Type<X>[]): TypeParameterApplication<X, T> {

--- a/packages/flow-runtime/src/types/TypeParameter.js
+++ b/packages/flow-runtime/src/types/TypeParameter.js
@@ -3,9 +3,7 @@
 import Type from './Type';
 import type Validation, {IdentifierPath} from '../Validation';
 
-export type TypeParameterStatus = 'open' | 'closed';
-
-import {TypeParameterStatusSymbol} from '../symbols';
+import FlowIntoType from './FlowIntoType';
 
 /**
  * # TypeParameter
@@ -21,47 +19,17 @@ export default class TypeParameter<T> extends Type {
 
   recorded: ? Type<T>;
 
-  // @flowIssue 252
-  [TypeParameterStatusSymbol]: TypeParameterStatus = 'closed';
-
-  /**
-   * Determines whether the type parameter is "open" or not.
-   * An open type parameter will make a union of all types it receives,
-   * a closed type parameter will adopt the first type it sees and use that
-   * for all subsequent checks.
-   */
-  get isOpen (): boolean {
-    return (this: $FlowIssue<252>)[TypeParameterStatusSymbol] === 'open';
-  }
 
   collectErrors (validation: Validation<any>, path: IdentifierPath, input: any): boolean {
-    const {recorded, bound, context, isOpen} = this;
-    if (bound instanceof TypeParameter && bound.isOpen) {
-      // We're bound with a type parameter which is open.
+    const {recorded, bound, context} = this;
+    if (bound instanceof FlowIntoType) {
       // We defer to the other type parameter so that values from this
       // one can flow "upwards".
-      return bound.collectErrors(validation, path, input);
+      return bound.accepts(input);
     }
-    if (recorded) {
+    else if (recorded) {
       // we've already recorded a value for this type parameter
-      if (isOpen) {
-        if (bound && bound.collectErrors(validation, path, input)) {
-          return true;
-        }
-        else if (recorded.accepts(input)) {
-          // our existing type already permits this value, there's nothing to do.
-          return false;
-        }
-        else {
-          // we need to make a union
-          this.recorded = context.union(recorded, context.typeOf(input));
-          return false;
-        }
-      }
-      else {
-        // when type parameters are closed we check against the recorded value.
-        return recorded.collectErrors(validation, path, input);
-      }
+      return recorded.collectErrors(validation, path, input);
     }
     else if (bound) {
       if (bound.typeName === 'AnyType' || bound.typeName === 'ExistentialType') {
@@ -77,29 +45,14 @@ export default class TypeParameter<T> extends Type {
   }
 
   accepts (input: any): boolean {
-    const {recorded, bound, context, isOpen} = this;
-    if (bound instanceof TypeParameter && bound.isOpen) {
-      // We're bound with a type parameter which is open.
+    const {recorded, bound, context} = this;
+    if (bound instanceof FlowIntoType) {
       // We defer to the other type parameter so that values from this
       // one can flow "upwards".
       return bound.accepts(input);
     }
-    if (recorded) {
-      if (isOpen) {
-        if (bound && !bound.accepts(input)) {
-          return false;
-        }
-        else if (recorded.accepts(input)) {
-          return true;
-        }
-        else {
-          this.recorded = context.union(recorded, context.typeOf(input));
-          return true;
-        }
-      }
-      else {
-        return recorded.accepts(input);
-      }
+    else if (recorded) {
+      return recorded.accepts(input);
     }
     else if (bound) {
       if (bound.typeName === 'AnyType' || bound.typeName === 'ExistentialType') {
@@ -118,7 +71,7 @@ export default class TypeParameter<T> extends Type {
     const {recorded, bound} = this;
     if (input instanceof TypeParameter) {
       // We don't need to check for `recorded` or `bound` fields
-      // because the input has already been resolved.
+      // because the input has already been unwrapped.
       return true;
     }
     else if (recorded) {
@@ -164,25 +117,5 @@ export default class TypeParameter<T> extends Type {
       bound: this.bound,
       recorded: this.recorded
     };
-  }
-}
-
-/**
- * Open the given type parameters.
- */
-export function openTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
-  const {length} = typeParameters;
-  for (let i = 0; i < length; i++) {
-    (typeParameters[i]: $FlowIssue<252>)[TypeParameterStatusSymbol] = 'open';
-  }
-}
-
-/**
- * Close the given type parameters.
- */
-export function closeTypeParameters <T> (...typeParameters: TypeParameter<T>[]) {
-  const {length} = typeParameters;
-  for (let i = 0; i < length; i++) {
-    (typeParameters[i]: $FlowIssue<252>)[TypeParameterStatusSymbol] = 'closed';
   }
 }

--- a/packages/flow-runtime/src/types/index.js
+++ b/packages/flow-runtime/src/types/index.js
@@ -40,6 +40,7 @@ import BooleanLiteralType from './BooleanLiteralType';
 import BooleanType from './BooleanType';
 import EmptyType from './EmptyType';
 import ExistentialType from './ExistentialType';
+import FlowIntoType from './FlowIntoType';
 import FunctionType from './FunctionType';
 import FunctionTypeParam from './FunctionTypeParam';
 import FunctionTypeRestParam from './FunctionTypeRestParam';
@@ -82,6 +83,7 @@ export {
   BooleanType,
   EmptyType,
   ExistentialType,
+  FlowIntoType,
   FunctionType,
   FunctionTypeParam,
   FunctionTypeRestParam,


### PR DESCRIPTION
Previously a parameterized function like this:
```js
function demo <T> (a: T, b: T): T[] {
  return [a, b];
}
```
would expect `a` and `b` to always have the same type, so this would work:
```js
demo(1, 2);
```
but this would fail:
```js
demo(1, true); // throws expected b to be number
```

This happened because we took the first value a type parameter received and used that for all subsequent checks. This isn't flow compatible. Flow would actually create a union in this case, so `T` would be `number | boolean`. 

We solve the problem by adding a `FlowIntoType` (if anyone has a better name please suggest it). It's essentially a virtual type which "expands" the set of permitted values for a type parameter with every type it receives. With the babel plugin we inject this into suitable positions, for example:
```js
type Thing<T> = {
  a: T,
  b: T
};

function demo <T> (input: Thing<T>): T[] {
 return [
   input.a,
   input.b
 ];
}

console.log(demo({a: 123, b: true}));
``` 

compiles to:
```js
import t from "flow-runtime";
const Thing = t.type("Thing", Thing => {
  const T = Thing.typeParameter("T");
  return t.object(t.property("a", T), t.property("b", T));
});

function demo(input) {
  const T = t.typeParameter("T");

  let _inputType = t.ref(Thing, t.flowInto(T));

  const _returnType = t.return(t.array(T));

  t.param("input", _inputType).assert(input);

  return _returnType.assert([input.a, input.b]);
}

console.log(demo({ a: 123, b: true }));
```

cc @gcanti who raised the issue