### PR TITLE
Flow-runtime: handle undefined in nullable assertions

### DIFF
--- a/packages/flow-runtime/src/typed.test.js
+++ b/packages/flow-runtime/src/typed.test.js
@@ -24,6 +24,28 @@ describe('Typed API', () => {
     }));
   });
 
+  it('should check nullable types', () => {
+    const type = t.nullable(t.string());
+
+    ok(type.accepts());
+    ok(type.accepts(null));
+    ok(type.accepts(undefined));
+    ok(type.accepts(''));
+    ok(type.accepts('foo'));
+    no(type.accepts(2));
+    no(type.accepts(true));
+  });
+
+  it('should assert nullable types', () => {
+    const type = t.nullable(t.string());
+
+    type.assert();
+    type.assert(null);
+    type.assert(undefined);
+    type.assert('');
+    type.assert('foo');
+  });
+
 
   it('should check a simple object with shortcut syntax', () => {
     const type = t.exactObject({

--- a/packages/flow-runtime/src/types/NullableType.js
+++ b/packages/flow-runtime/src/types/NullableType.js
@@ -9,7 +9,7 @@ export default class NullableType<T> extends Type {
   type: Type<T>;
 
   collectErrors (validation: Validation<any>, path: IdentifierPath, input: any): boolean {
-    if (input === null) {
+    if (input == null) {
       return false;
     }
     else {


### PR DESCRIPTION
Void is a legal inhabitant of the nullable type according to the flow spec. 

The bug caused assertions to fail when they shouldn't.

This PR fixes the assertions of undefined for nullable types, and adds test cases.
