### PR TITLE
Support classes

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/ConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/ConversionContext.js
@@ -265,6 +265,44 @@ export default class ConversionContext {
     this.visited.add(replacement);
     path.replaceWith(replacement);
   }
+
+  getClassData (path: NodePath, key: string): any {
+    const candidates = path.scope.getData(`classData:${key}`);
+    if (candidates instanceof Map) {
+      const declaration = path.isClass()
+                        ? path
+                        : path.findParent(item => item.isClass())
+                        ;
+
+      if (declaration) {
+        return candidates.get(declaration.node);
+      }
+      else {
+        console.warn('Could not find class declaration to get data from:', key);
+      }
+    }
+  }
+
+  setClassData (path: NodePath, key: string, value: any) {
+    const {scope} = path;
+    const qualifiedKey = `classData:${key}`;
+    const declaration = path.isClass()
+                      ? path
+                      : path.findParent(item => item.isClass())
+                      ;
+    if (!declaration) {
+      console.warn('Could not find class declaration to set data on:', key);
+      return;
+    }
+
+    let map = scope.data[qualifiedKey];
+    if (!(map instanceof Map)) {
+      map = new Map();
+      scope.data[qualifiedKey] = map;
+    }
+
+    map.set(declaration.node, value);
+  }
 }
 
 function filterBlockParent (item: NodePath): NodePath {

--- a/packages/babel-plugin-flow-runtime/src/ConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/ConversionContext.js
@@ -16,7 +16,7 @@ export default class ConversionContext {
   shouldImport: boolean = true;
   shouldAssert: boolean = true;
   shouldWarn: boolean = false;
-  shouldDecorate: boolean = true;
+  shouldAnnotate: boolean = true;
   suppressCommentPatterns: RegExp[] = [/\$FlowFixMe/];
   suppressTypeNames: string[] = ['$FlowFixMe'];
 

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/14-exportDefaultFunctionNoName.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/14-exportDefaultFunctionNoName.js
@@ -20,7 +20,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   export default t.annotate(
     function (a, b) {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/24-allow-import-star-react.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/24-allow-import-star-react.js
@@ -17,8 +17,8 @@ class Point extends R.Component {
 `;
 
 export const expected = `
-import t from "flow-runtime";
 import * as R from 'react';
+import t from "flow-runtime";
 
 const Props = t.type("Props", t.object(
   t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/28-decorate-with-export-default.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/28-decorate-with-export-default.js
@@ -17,7 +17,7 @@ export default function test(id) {
 `;
 
 
-export const decorated = `
+export const annotated = `
 import t from "flow-runtime";
 export default function test(id) {
   return id;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
@@ -6,7 +6,7 @@ export const input = `
 `;
 
 export const expected = `
-  import _t from "flow-runtime";
   import t from "babel-types";
+  import _t from "flow-runtime";
   const Demo = _t.type("Demo", _t.number());
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReifyNoDefault.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReifyNoDefault.js
@@ -8,9 +8,9 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import { reify } from "flow-runtime";
   import { Type } from "flow-runtime";
+  import t from "flow-runtime";
   const Demo = t.type("Demo", t.number());
   console.log(Demo);
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestImportType.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestImportType.js
@@ -12,8 +12,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import { Demo } from './simplestExportType';
+  import t from "flow-runtime";
 
   const Local = t.type("Local", t.number());
 

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/pragma/pragmaWarnAndDecorate.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/pragma/pragmaWarnAndDecorate.js
@@ -2,7 +2,7 @@
 
 export const input = `
 /* @flow */
-/* @flow-runtime warn, decorate */
+/* @flow-runtime warn, annotate */
 
 type Demo = 123;
 
@@ -14,7 +14,7 @@ const demo = ([foo]: string[]): string => foo;
 export const expected = `
 import t from "flow-runtime";
 /* @flow */
-/* @flow-runtime warn, decorate */
+/* @flow-runtime warn, annotate */
 
 const Demo = t.type("Demo", t.number(123));
 

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/pragma/suppressCommentClass.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/pragma/suppressCommentClass.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+export const input = `
+/* @flow */
+
+type Demo = false;
+
+class Thing {
+  // $FlowFixMe
+  a: string;
+
+  b: Demo;
+}
+`;
+
+export const expected = `
+import t from "flow-runtime";
+/* @flow */
+
+const Demo = t.type("Demo", t.boolean(false));
+
+class Thing {
+  // $FlowFixMe
+  a;
+
+  @t.decorate(Demo)
+  b;
+}
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
@@ -21,7 +21,7 @@ export const expected = `
 
 export const decorated = `
   import t from "flow-runtime";
-  @t.decorate(t.class("User"))
+  @t.annotate(t.class("User"))
   class User {}
 
   function demo(model) {}
@@ -36,7 +36,7 @@ export const decorated = `
 
 export const combined = `
   import t from "flow-runtime";
-  @t.decorate(t.class("User"))
+  @t.annotate(t.class("User"))
   class User {}
 
   function demo(model) {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
@@ -19,7 +19,7 @@ export const expected = `
   }
 `;
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   @t.annotate(t.class("User"))
   class User {}

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/specialForms/classAnnotation.js
@@ -21,6 +21,7 @@ export const expected = `
 
 export const decorated = `
   import t from "flow-runtime";
+  @t.decorate(t.class("User"))
   class User {}
 
   function demo(model) {}
@@ -35,6 +36,7 @@ export const decorated = `
 
 export const combined = `
   import t from "flow-runtime";
+  @t.decorate(t.class("User"))
   class User {}
 
   function demo(model) {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/classWithTypeParametersAndStaticMethods.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/classWithTypeParametersAndStaticMethods.js
@@ -19,22 +19,27 @@ export const input = `
 export const expected = `
   import t from "flow-runtime";
 
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
   class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     x = 0;
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     y = 0;
 
     constructor(x, y) {
-      this[t.TypeParametersSymbol] = {
+      this[_PointTypeParametersSymbol] = {
         T: t.typeParameter("T", t.number())
       };
-      let _xType = this[t.TypeParametersSymbol].T;
-      let _yType = this[t.TypeParametersSymbol].T;
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
       t.param("x", _xType).assert(x);
       t.param("y", _yType).assert(y);
       this.x = x;
@@ -45,8 +50,8 @@ export const expected = `
       const _typeParameters = {
         T: t.typeParameter("T", t.number())
       };
-      let _xType2 = _typeParameters.T;
-      let _yType2 = _typeParameters.T;
+      let _xType2 = t.flowInto(_typeParameters.T);
+      let _yType2 = t.flowInto(_typeParameters.T);
       const _returnType = t.return(t.ref(Point, _typeParameters.T));
       t.param("x", _xType2).assert(x);
       t.param("y", _yType2).assert(y);

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClass.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClass.js
@@ -20,7 +20,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassNoDefaults.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassNoDefaults.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+export const input = `
+  class Point {
+    x: number;
+    y: number;
+  }
+`;
+
+export const expected = `
+  import t from "flow-runtime";
+
+  class Point {
+    @t.decorate(t.number())
+    x;
+
+    @t.decorate(t.number())
+    y;
+  }
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithAccessors.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithAccessors.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+export const input = `
+  class Point {
+    x: number = 0;
+    y: number = 0;
+
+    get foo (): boolean {
+      return true;
+    }
+  }
+`;
+
+export const expected = `
+  import t from "flow-runtime";
+
+  class Point {
+    @t.decorate(t.number())
+    x = 0;
+
+    @t.decorate(t.number())
+    y = 0;
+
+    get foo() {
+      const _returnType = t.return(t.boolean());
+      return _returnType.assert(true);
+    }
+  }
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithComputedProperty.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithComputedProperty.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+export const input = `
+  class Point {
+    x: number = 0;
+    y: number = 0;
+
+    ["foo"]: boolean;
+  }
+`;
+
+export const expected = `
+  import t from "flow-runtime";
+
+  class Point {
+    @t.decorate(t.number())
+    x = 0;
+
+    @t.decorate(t.number())
+    y = 0;
+
+    ["foo"];
+  }
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithMethodWithDefaultArg.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithMethodWithDefaultArg.js
@@ -32,7 +32,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithMethodWithDefaultArg.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithMethodWithDefaultArg.js
@@ -1,0 +1,83 @@
+/* @flow */
+
+export const input = `
+  class Point {
+    x: number = 0;
+    y: number = 0;
+
+    z (a: string = "123"): string {
+      return a;
+    }
+
+  }
+`;
+
+export const expected = `
+  import t from "flow-runtime";
+
+  class Point {
+    @t.decorate(t.number())
+    x = 0;
+
+    @t.decorate(t.number())
+    y = 0;
+
+    z(a = "123") {
+      let _aType = t.string();
+      const _returnType = t.return(t.string());
+      t.param("a", _aType).assert(a);
+      return _returnType.assert(a);
+    }
+  }
+`;
+
+
+export const decorated = `
+  import t from "flow-runtime";
+
+  @t.annotate(t.class(
+    "Point",
+    t.property("x", t.number()),
+    t.property("y", t.number()),
+    t.method("z",
+      t.param("a", t.string()),
+      t.return(t.string())
+    )
+  ))
+  class Point {
+    x = 0;
+    y = 0;
+
+    z(a = "123") {
+      return a;
+    }
+  }
+`;
+
+export const combined = `
+  import t from "flow-runtime";
+
+  @t.annotate(t.class(
+    "Point",
+    t.property("x", t.number()),
+    t.property("y", t.number()),
+    t.method("z",
+      t.param("a", t.string()),
+      t.return(t.string())
+    )
+  ))
+  class Point {
+    @t.decorate(t.number())
+    x = 0;
+
+    @t.decorate(t.number())
+    y = 0;
+
+    z(a = "123") {
+      let _aType = t.string();
+      const _returnType = t.return(t.string());
+      t.param("a", _aType).assert(a);
+      return _returnType.assert(a);
+    }
+  }
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithParent.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithParent.js
@@ -25,7 +25,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithParent.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithParent.js
@@ -1,8 +1,11 @@
 /* @flow */
 
 export const input = `
-  class Point {
+  class Parent {
     x: number = 0;
+  }
+
+  class Child extends Parent {
     y: number = 0;
   }
 `;
@@ -10,10 +13,12 @@ export const input = `
 export const expected = `
   import t from "flow-runtime";
 
-  class Point {
+  class Parent {
     @t.decorate(t.number())
     x = 0;
+  }
 
+  class Child extends Parent {
     @t.decorate(t.number())
     y = 0;
   }
@@ -24,12 +29,19 @@ export const decorated = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(
-    "Point",
-    t.property("x", t.number()),
-    t.property("y", t.number())
+    "Parent",
+    t.property("x", t.number())
   ))
-  class Point {
+  class Parent {
     x = 0;
+  }
+
+  @t.annotate(t.class(
+    "Child",
+    t.property("y", t.number()),
+    t.extends(Parent)
+  ))
+  class Child extends Parent {
     y = 0;
   }
 `;
@@ -38,14 +50,20 @@ export const combined = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(
-    "Point",
-    t.property("x", t.number()),
-    t.property("y", t.number())
+    "Parent",
+    t.property("x", t.number())
   ))
-  class Point {
+  class Parent {
     @t.decorate(t.number())
     x = 0;
+  }
 
+  @t.annotate(t.class(
+    "Child",
+    t.property("y", t.number()),
+    t.extends(Parent)
+  ))
+  class Child extends Parent {
     @t.decorate(t.number())
     y = 0;
   }

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
@@ -20,7 +20,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
 
   @t.annotate(t.class(

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
@@ -23,7 +23,7 @@ export const expected = `
 export const decorated = `
   import t from "flow-runtime";
 
-  @t.decorate(t.class(
+  @t.annotate(t.class(
     "Point",
     t.property("x", t.number()),
     t.staticProperty("y", t.number())
@@ -37,7 +37,7 @@ export const decorated = `
 export const combined = `
   import t from "flow-runtime";
 
-  @t.decorate(t.class(
+  @t.annotate(t.class(
     "Point",
     t.property("x", t.number()),
     t.staticProperty("y", t.number())

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithStatics.js
@@ -3,7 +3,7 @@
 export const input = `
   class Point {
     x: number = 0;
-    y: number = 0;
+    static y: number = 0;
   }
 `;
 
@@ -15,7 +15,7 @@ export const expected = `
     x = 0;
 
     @t.decorate(t.number())
-    y = 0;
+    static y = 0;
   }
 `;
 
@@ -26,11 +26,11 @@ export const decorated = `
   @t.decorate(t.class(
     "Point",
     t.property("x", t.number()),
-    t.property("y", t.number())
+    t.staticProperty("y", t.number())
   ))
   class Point {
     x = 0;
-    y = 0;
+    static y = 0;
   }
 `;
 
@@ -40,13 +40,13 @@ export const combined = `
   @t.decorate(t.class(
     "Point",
     t.property("x", t.number()),
-    t.property("y", t.number())
+    t.staticProperty("y", t.number())
   ))
   class Point {
     @t.decorate(t.number())
     x = 0;
 
     @t.decorate(t.number())
-    y = 0;
+    static y = 0;
   }
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/simplestClassWithTypeParameters.js
@@ -15,22 +15,27 @@ export const input = `
 export const expected = `
   import t from "flow-runtime";
 
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
   class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     x = 0;
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     y = 0;
 
     constructor(x, y) {
-      this[t.TypeParametersSymbol] = {
+      this[_PointTypeParametersSymbol] = {
         T: t.typeParameter("T", t.number())
       };
-      let _xType = this[t.TypeParametersSymbol].T;
-      let _yType = this[t.TypeParametersSymbol].T;
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
       t.param("x", _xType).assert(x);
       t.param("y", _yType).assert(y);
       this.x = x;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/typeParametersWithInheritance.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/typeParametersWithInheritance.js
@@ -74,14 +74,9 @@ export const expected = `
       const _typeParameters3 = {
         F: t.typeParameter("F", Float)
       };
-      t.param("arguments[0]", t.tuple(_typeParameters3.F, _typeParameters3.F)).assert(arguments[0]);
+      t.param("arguments[0]", t.tuple(t.flowInto(_typeParameters3.F), t.flowInto(_typeParameters3.F))).assert(arguments[0]);
       super(x, y);
-      if (this[_FPointTypeParametersSymbol]) {
-        Object.assign(this[_FPointTypeParametersSymbol], _typeParameters3);
-      }
-      else {
-        this[_FPointTypeParametersSymbol] = _typeParameters3;
-      }
+      this[_FPointTypeParametersSymbol] = _typeParameters3;
       t.bindTypeParameters(this, this[_FPointTypeParametersSymbol].F);
     }
   }

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/typeParametersWithInheritance.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/classes/typeParametersWithInheritance.js
@@ -28,22 +28,27 @@ export const input = `
 export const expected = `
   import t from "flow-runtime";
 
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
   class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     x = 0;
     @t.decorate(function () {
-      return this[t.TypeParametersSymbol].T;
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
     })
     y = 0;
 
     constructor(x, y) {
-      this[t.TypeParametersSymbol] = {
+      this[_PointTypeParametersSymbol] = {
         T: t.typeParameter("T", t.number())
       };
-      let _xType = this[t.TypeParametersSymbol].T;
-      let _yType = this[t.TypeParametersSymbol].T;
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
       t.param("x", _xType).assert(x);
       t.param("y", _yType).assert(y);
       this.x = x;
@@ -60,20 +65,24 @@ export const expected = `
     }
   }
 
+  const _FPointTypeParametersSymbol = Symbol("FPointTypeParameters");
+
   class FPoint extends Point {
+    static [t.TypeParametersSymbol] = _FPointTypeParametersSymbol;
+
     constructor([x, y]) {
       const _typeParameters3 = {
         F: t.typeParameter("F", Float)
       };
       t.param("arguments[0]", t.tuple(_typeParameters3.F, _typeParameters3.F)).assert(arguments[0]);
       super(x, y);
-      if (this[t.TypeParametersSymbol]) {
-        Object.assign(this[t.TypeParametersSymbol], _typeParameters3);
+      if (this[_FPointTypeParametersSymbol]) {
+        Object.assign(this[_FPointTypeParametersSymbol], _typeParameters3);
       }
       else {
-        this[t.TypeParametersSymbol] = _typeParameters3;
+        this[_FPointTypeParametersSymbol] = _typeParameters3;
       }
-      t.bindTypeParameters(this, this[t.TypeParametersSymbol].F);
+      t.bindTypeParameters(this, this[_FPointTypeParametersSymbol].F);
     }
   }
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/arrayPattern.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/arrayPattern.js
@@ -13,7 +13,7 @@ export const expected = `
   };
 `;
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   const demo = t.annotate(
     ([foo]) => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/boundTypeParameter.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/boundTypeParameter.js
@@ -16,7 +16,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   const demo = t.annotate(
     input => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/defaultParam.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/defaultParam.js
@@ -15,7 +15,7 @@ export const expected = `
 `;
 
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   const demo = t.annotate(
     (input = "Hello World") => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/delegatingGeneratorFunction.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/delegatingGeneratorFunction.js
@@ -16,7 +16,7 @@ export const expected = `
   }
 `;
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   function* demo() {
     yield* "hello world";

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/multipleParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/functions/multipleParameters.js
@@ -16,7 +16,7 @@ export const expected = `
   };
 `;
 
-export const decorated = `
+export const annotated = `
   import t from "flow-runtime";
   const demo = t.annotate(
     (a, b) => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/modules/simplestImport.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/modules/simplestImport.js
@@ -5,9 +5,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
-
   import {
     Demo
   } from './simplestExport';
+  import t from "flow-runtime";
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactClassWithTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactClassWithTypeParameters.js
@@ -16,8 +16,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import React from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportComponent.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportComponent.js
@@ -16,8 +16,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import { Component } from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportComponentWithAlias.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportComponentWithAlias.js
@@ -16,8 +16,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import { Component as C } from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportPureComponent.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactImportPureComponent.js
@@ -16,8 +16,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import { PureComponent } from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactPureComponent.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/reactPureComponent.js
@@ -16,8 +16,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import React from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/simplestReactClass.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAssertions/react/simplestReactClass.js
@@ -17,8 +17,8 @@ export const input = `
 `;
 
 export const expected = `
-  import t from "flow-runtime";
   import React from "react";
+  import t from "flow-runtime";
 
   const Props = t.type("Props", t.object(
     t.property("x", t.number()),

--- a/packages/babel-plugin-flow-runtime/src/__tests__/fixtures.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/fixtures.js
@@ -40,7 +40,7 @@ const files = findFiles(fixturesDir, []);
 export type Fixture = {
   input: string;
   expected: string;
-  decorated?: string;
+  annotated?: string;
   combined?: string;
 };
 

--- a/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
@@ -13,25 +13,25 @@ import type {Node, NodePath} from 'babel-traverse';
 
 
 describe('transform', () => {
-  for (const [name, {input, expected, decorated, combined}] of fixtures) {
+  for (const [name, {input, expected, annotated, combined}] of fixtures) {
     it(`should transform ${name}`, () => {
       const parsed = parse(input);
       const transformed = stripFlowTypes(transform(parsed, {
         assert: true,
-        decorate: false
+        annotate: false
       }));
       const generated = generate(transformed).code;
       equal(normalize(generated), normalize(expected));
     });
-    if (decorated) {
+    if (annotated) {
       it(`should transform ${name} with decorations`, () => {
         const parsed = parse(input);
         const transformed = stripFlowTypes(transform(parsed, {
           assert: false,
-          decorate: true
+          annotate: true
         }));
         const generated = generate(transformed).code;
-        equal(normalize(generated), normalize(decorated));
+        equal(normalize(generated), normalize(annotated));
       });
     }
     if (combined) {
@@ -39,7 +39,7 @@ describe('transform', () => {
         const parsed = parse(input);
         const transformed = stripFlowTypes(transform(parsed, {
           assert: true,
-          decorate: true
+          annotate: true
         }));
         const generated = generate(transformed).code;
         equal(normalize(generated), normalize(combined));

--- a/packages/babel-plugin-flow-runtime/src/attachImport.js
+++ b/packages/babel-plugin-flow-runtime/src/attachImport.js
@@ -10,12 +10,21 @@ export default function attachImport (context: ConversionContext, program: NodeP
     [t.importDefaultSpecifier(t.identifier(context.libraryId))],
     t.stringLiteral(context.libraryName)
   );
+  let last;
   for (const item of program.get('body')) {
-    if (item.type === 'Directive') {
+    if (item.isDirective() || item.isImportDeclaration()) {
+      last = item;
       continue;
     }
+
     item.insertBefore(importDeclaration);
     return;
   }
-  program.insertAfter(importDeclaration);
+
+  if (last) {
+    last.insertAfter(importDeclaration);
+  }
+  else {
+    program.get('body').unshiftContainer('body', importDeclaration);
+  }
 }

--- a/packages/babel-plugin-flow-runtime/src/collectProgramOptions.js
+++ b/packages/babel-plugin-flow-runtime/src/collectProgramOptions.js
@@ -8,7 +8,7 @@ import type {Options} from './createConversionContext';
 /**
  * Collects the program level pragmas which override the plugin options.
  * Pragmas are specified via comments like `@flow-runtime ignore`
- * and `@flow-runtime warn, decorate`.
+ * and `@flow-runtime warn, annotate`.
  * Collected options are applied to the conversion context, if the program
  * has a `@flow-runtime ignore` comment or doesn't use any flow types this function
  * will return `false`, if any other flow-runtime pragmas are present or the file
@@ -33,8 +33,8 @@ export default function collectProgramOptions (context: ConversionContext, node:
   if (options.warn) {
     context.shouldWarn = true;
   }
-  if (options.decorate) {
-    context.shouldDecorate = true;
+  if (options.annotate) {
+    context.shouldAnnotate = true;
   }
   return true;
 }
@@ -53,7 +53,7 @@ function collectOptionsFromPragma (context: ConversionContext, node: Node): ? Op
           // we have a comment but no options, this is strict by default.
           return {
             assert: true,
-            decorate: true
+            annotate: true
           };
         }
         else {

--- a/packages/babel-plugin-flow-runtime/src/convert.js
+++ b/packages/babel-plugin-flow-runtime/src/convert.js
@@ -61,7 +61,7 @@ function typeParameterCanFlow (annotation: NodePath) {
       return false;
     }
 
-    if (subject.isIdentifier()) {
+    if (subject.isIdentifier() || subject.isArrayPattern() || subject.isObjectPattern()) {
       if (subject.parentPath.isFunction() && subject.listKey === 'params') {
         return true;
       }

--- a/packages/babel-plugin-flow-runtime/src/createConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/createConversionContext.js
@@ -6,6 +6,8 @@ export type Options = {
   ignore?: boolean;
   assert?: boolean;
   warn?: boolean;
+  annotate?: boolean;
+  // deprecated
   decorate?: boolean;
 };
 
@@ -20,9 +22,16 @@ export default function createConversionContext (options: Options): ConversionCo
 
   context.shouldWarn = options.warn ? true : false;
 
-  context.shouldDecorate = options.decorate === 'undefined'
+  if ('decorate' in options) {
+    console.warn('Warning: "decorate" option for babel-plugin-flow-runtime is now called "annotate", support for "decorate" will be removed in a future version.');
+    if (!('annotate' in options)) {
+      options.annotate = options.decorate;
+    }
+  }
+
+  context.shouldAnnotate = options.annotate === 'undefined'
                          ? true
-                         : Boolean(options.decorate)
+                         : Boolean(options.annotate)
                          ;
   return context;
 }

--- a/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
@@ -115,10 +115,17 @@ export default function firstPassVisitors (context: ConversionContext): Object {
       }
     },
     Class (path: NodePath) {
+      let className = 'AnonymousClass';
       if (path.isClassDeclaration() && path.has('id')) {
         const {name} = path.node.id;
+        className = name;
         context.defineValue(name, path.parentPath);
       }
+      context.setClassData(
+        path,
+        'currentClassName',
+        className
+      );
       const typeParameters = getTypeParameters(path);
       typeParameters.forEach(item => {
         const {name} = item.node;
@@ -126,7 +133,26 @@ export default function firstPassVisitors (context: ConversionContext): Object {
       });
       if (typeParameters.length > 0 || path.has('superTypeParameters')) {
         ensureConstructor(path);
-        path.parentPath.scope.setData('typeParametersUid', path.parentPath.scope.generateUid('typeParameters'));
+        context.setClassData(
+          path,
+          'typeParametersUid',
+          path.parentPath.scope.generateUid(`_typeParameters`)
+        );
+      }
+
+      if (typeParameters.length > 0) {
+        context.setClassData(
+          path,
+          'typeParametersSymbolUid',
+          path.parentPath.scope.generateUid(`${className}TypeParametersSymbol`)
+        );
+      }
+      else {
+        context.setClassData(
+          path,
+          'typeParametersSymbolUid',
+          ''
+        );
       }
     }
   };

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -702,7 +702,7 @@ export default function transformVisitors (context: ConversionContext): Object {
             ;
         const hasTypeParameters = typeParameters.length > 0;
         const hasSuperTypeParameters = superTypeParameters.length > 0;
-        if (!hasTypeParameters && !hasSuperTypeParameters) {
+        if (!shouldCheck || (!hasTypeParameters && !hasSuperTypeParameters)) {
           // Nothing to do here.
           return;
         }
@@ -797,7 +797,7 @@ export default function transformVisitors (context: ConversionContext): Object {
         path.skip();
         return;
       }
-      if (!path.has('typeAnnotation')) {
+      if (!shouldCheck || !path.has('typeAnnotation') || path.node.computed) {
         return;
       }
       const typeAnnotation = path.get('typeAnnotation');

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -737,28 +737,12 @@ export default function transformVisitors (context: ConversionContext): Object {
             ));
 
             trailer.push(
-              t.ifStatement(
-                thisTypeParameters,
-                t.blockStatement([
-                  t.expressionStatement(
-                    t.callExpression(
-                      t.memberExpression(
-                        t.identifier('Object'),
-                        t.identifier('assign')
-                      ),
-                      [thisTypeParameters, typeParametersUid]
-                    )
-                  )
-                ]),
-                t.blockStatement([
-                  t.expressionStatement(
-                    t.assignmentExpression(
-                      '=',
-                      thisTypeParameters,
-                      typeParametersUid
-                    )
-                  )
-                ])
+              t.expressionStatement(
+                t.assignmentExpression(
+                  '=',
+                  thisTypeParameters,
+                  typeParametersUid
+                )
               )
             );
           }

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -30,7 +30,7 @@ type ClassSignature = {
 
 export default function transformVisitors (context: ConversionContext): Object {
   const shouldCheck = context.shouldAssert || context.shouldWarn;
-  const shouldDecorate = context.shouldDecorate;
+  const shouldAnnotate = context.shouldAnnotate;
   const nodeSignatures: WeakMap<Node, FunctionSignature | ClassSignature> = new WeakMap();
   return {
     Program (path: NodePath) {
@@ -305,7 +305,7 @@ export default function transformVisitors (context: ConversionContext): Object {
               context.call('typeParameter', ...args)
             )
           ]));
-          if (shouldDecorate) {
+          if (shouldAnnotate) {
             signature.typeParameters.push([name, args]);
           }
         }
@@ -332,7 +332,7 @@ export default function transformVisitors (context: ConversionContext): Object {
           }
 
           if (!param.has('typeAnnotation')) {
-            if (shouldDecorate) {
+            if (shouldAnnotate) {
               signature.params.push(context.call(
                 'param',
                 t.stringLiteral(argumentName),
@@ -345,7 +345,7 @@ export default function transformVisitors (context: ConversionContext): Object {
           signature.hasTypeAnnotations = true;
 
           if (param.isObjectPattern() || param.isArrayPattern()) {
-            if (shouldDecorate) {
+            if (shouldAnnotate) {
               signature.params.push(context.call(
                 'param',
                 t.stringLiteral(argumentName),
@@ -398,7 +398,7 @@ export default function transformVisitors (context: ConversionContext): Object {
             if (param.isRestElement()) {
               methodName = 'rest';
               name = param.node.argument.name;
-              if (shouldDecorate) {
+              if (shouldAnnotate) {
                 signature.params.push(context.call(
                   'rest',
                   t.stringLiteral(name),
@@ -408,7 +408,7 @@ export default function transformVisitors (context: ConversionContext): Object {
             }
             else {
               invariant(param.isIdentifier(), 'Param must be an identifier');
-              if (shouldDecorate) {
+              if (shouldAnnotate) {
                 signature.params.push(context.call(
                   'param',
                   t.stringLiteral(name),
@@ -445,7 +445,7 @@ export default function transformVisitors (context: ConversionContext): Object {
           if (returnType.type === 'TypeAnnotation') {
             returnType = returnType.get('typeAnnotation');
           }
-          if (shouldDecorate) {
+          if (shouldAnnotate) {
             signature.returnType = context.call(
               'return',
               convert(context, returnType)
@@ -506,7 +506,7 @@ export default function transformVisitors (context: ConversionContext): Object {
       },
       exit (path: NodePath) {
         const signature = nodeSignatures.get(path.node);
-        if (!shouldDecorate || !signature || !Array.isArray(signature.params) || !signature.hasTypeAnnotations || path.isClassMethod()) {
+        if (!shouldAnnotate || !signature || !Array.isArray(signature.params) || !signature.hasTypeAnnotations || path.isClassMethod()) {
           return;
         }
         let decoration;
@@ -754,7 +754,7 @@ export default function transformVisitors (context: ConversionContext): Object {
         const hasTypeParameters = typeParameters.length > 0;
         const hasSuperTypeParameters = superTypeParameters.length > 0;
         const signature = nodeSignatures.get(path.node);
-        if (shouldDecorate && signature) {
+        if (shouldAnnotate && signature) {
 
           const {name, properties, methods} = ((signature: any): ClassSignature);
           const args = properties.concat(methods);

--- a/packages/flow-runtime-docs/src/Compiler.js
+++ b/packages/flow-runtime-docs/src/Compiler.js
@@ -130,7 +130,7 @@ export default class Compiler {
   @observable compiled: string;
   @observable shouldAssert: boolean;
   @observable shouldWarn: boolean;
-  @observable shouldDecorate: boolean;
+  @observable shouldAnnotate: boolean;
   @observable error: string;
   @observable.shallow log: Array<['log' | 'warn' | 'error' | 'react', string]> = [];
 
@@ -158,7 +158,7 @@ export default class Compiler {
     this.transformed = '';
     this.compiled = '';
     this.error = '';
-    this.shouldDecorate = true;
+    this.shouldAnnotate = true;
     this.shouldAssert = true;
     this.shouldWarn = false;
     this.updateCode(this.code);
@@ -169,7 +169,7 @@ export default class Compiler {
     try {
       const [transformed, compiled] = await compile(code, {
         assert: this.shouldAssert,
-        decorate: this.shouldDecorate,
+        annotate: this.shouldAnnotate,
         warn: this.shouldWarn
       });
 

--- a/packages/flow-runtime-docs/src/compiler.worker.js
+++ b/packages/flow-runtime-docs/src/compiler.worker.js
@@ -38,7 +38,10 @@ function transformFlowRuntime (ast: AST, input: string, options: Object): string
 }
 
 function compileBabel (ast: AST, input: string): string {
-  const {code} = Babel.transformFromAst(ast, input, { presets: [['es2015', {generators: false}], 'stage-0', 'react']});
+  const {code} = Babel.transformFromAst(ast, input, {
+    presets: [['es2015', {generators: false}], 'stage-0', 'react'],
+    plugins: ['transform-decorators-legacy']
+  });
   return code;
 }
 

--- a/packages/flow-runtime-docs/src/components/TryPage.js
+++ b/packages/flow-runtime-docs/src/components/TryPage.js
@@ -67,7 +67,7 @@ export default class TryPage extends Component<void, Props, void> {
 
 
   handleClickDecoration = () => {
-    this.compiler.shouldDecorate = !this.compiler.shouldDecorate;
+    this.compiler.shouldAnnotate = !this.compiler.shouldAnnotate;
     this.compiler.updateCode(this.compiler.code);
   };
 
@@ -94,7 +94,7 @@ export default class TryPage extends Component<void, Props, void> {
                 {compiler.shouldWarn ? 'Disable Warnings' : 'Enable Warnings'}
               </button>
               <button className="btn btn-secondary" onClick={this.handleClickDecoration}>
-                {compiler.shouldDecorate ? 'Disable Decorations' : 'Enable Decorations'}
+                {compiler.shouldAnnotate ? 'Disable Decorations' : 'Enable Decorations'}
               </button>
               <button className="btn btn-primary" onClick={this.runCode} disabled={!compiler.isReady}>
                 {!compiler.isReady && <i className="fa fa-spinner fa-pulse" />}

--- a/packages/flow-runtime-docs/src/components/docs/PragmasPage.js
+++ b/packages/flow-runtime-docs/src/components/docs/PragmasPage.js
@@ -55,14 +55,14 @@ export default class PragmasPage extends Component {
           <p>When used with Flow, they should appear <em>after</em> Flow's own special comment:</p>
           <pre>{'// @flow\n// @flow-runtime'}</pre>
           <p>The behaviour of the plugin changes depending on the options you specify at the end of the comment:</p>
-          <p><code>{'/* @flow-runtime */'}</code>: no options is the equivalent of specifying <code>{'/* @flow-runtime assert, decorate */'}</code>.</p>
+          <p><code>{'/* @flow-runtime */'}</code>: no options is the equivalent of specifying <code>{'/* @flow-runtime assert, annotate */'}</code>.</p>
           <p><code>{'/* @flow-runtime ignore */'}</code>: ignore the whole file, don't process it at all, no assertions or type transformations.</p>
           <p><code>{'/* @flow-runtime assert */'}</code>: any type error in the file will throw an exception.</p>
           <p><code>{'/* @flow-runtime warn */'}</code>: turns type errors into warnings rather than exceptions.</p>
-          <p><code>{'/* @flow-runtime decorate */'}</code>: functions and classes will be decorated with type annotations.</p>
+          <p><code>{'/* @flow-runtime annotate */'}</code>: functions and classes will be decorated with type annotations.</p>
           <br />
           <p>You can also specify multiple options at once:</p>
-          <p><code>{'/* @flow-runtime warn, decorate */'}</code>: type errors will produce warnings, functions and classes will be decorated with type annotations.</p>
+          <p><code>{'/* @flow-runtime warn, annotate */'}</code>: type errors will produce warnings, functions and classes will be decorated with type annotations.</p>
           <hr />
           <h4>Suppressing Individual Type Errors</h4>
           <p>Sometimes you need an escape hatch for code you know to be correct, but which doesn't type check for some reason.</p>

--- a/packages/flow-runtime-docs/src/components/packages/BabelPluginFlowRuntimePage.js
+++ b/packages/flow-runtime-docs/src/components/packages/BabelPluginFlowRuntimePage.js
@@ -22,7 +22,7 @@ const babelConfig = `
 {
   "plugins": [["flow-runtime", {
     "assert": true,
-    "decorate": true
+    "annotate": true
   }]]
 }
 `.trim();
@@ -95,7 +95,7 @@ export default class BabelPluginFlowRuntimePage extends Component {
               <ul>
                 <li><code>assert</code> - Boolean, indicates whether types should be asserted at runtime. Defaults to <code>true</code> if <code>process.env.NODE_ENV === 'development'</code>, otherwise <code>false</code>.</li>
                 <li><code>warn</code> - Boolean, if <code>true</code> flow-runtime will emit warnings instead of throwing in case of a failing check. This can be very useful when first introducing types to a codebase.</li>
-                <li><code>decorate</code> - Boolean, indicates whether object or function values that have type annotations should be decorated with those types at runtime. Defaults to <code>true</code>.</li>
+                <li><code>annotate</code> - Boolean, indicates whether object or function values that have type annotations should be annotated with those types at runtime. Defaults to <code>true</code>.</li>
               </ul>
               <p>You can override these plugin options on a per-file basis using <code>//@flow-runtime</code> comments, see the <Link to="/docs/pragmas">Pragmas</Link> documentation.</p>
               <Example code={adderExample}

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -503,9 +503,23 @@ export default class TypeContext {
     return flowIntoTypeParameter(typeParameter);
   }
 
+  /**
+   * Bind the type parameters for the parent class of the given instance.
+   */
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {
+
+    const instancePrototype = Object.getPrototypeOf(subject);
+    // @flowIssue
+    const parentPrototype = instancePrototype && Object.getPrototypeOf(instancePrototype);
+    // @flowIssue
+    const parentClass = parentPrototype && parentPrototype.constructor;
+
+    if (!parentClass) {
+      this.emitWarningMessage('Could not bind type parameters for non-existent parent class.');
+      return subject;
+    }
     // @flowIssue 252
-    const typeParametersPointer = subject[TypeParametersSymbol];
+    const typeParametersPointer = parentClass[TypeParametersSymbol];
 
     if (typeParametersPointer) {
       const typeParameters = subject[typeParametersPointer];

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -202,6 +202,7 @@ export default class TypeContext {
 
   /**
    * Get the predicate for a given type name.
+   * e.g. `t.getPredicate('Array')`.
    */
   getPredicate (name: string): ? TypePredicate {
     const item: ? TypePredicate = (this: any)[TypePredicateRegistrySymbol][name];
@@ -226,6 +227,7 @@ export default class TypeContext {
   /**
    * Check the given value against the named predicate.
    * Returns false if no such predicate exists.
+   * e.g. `t.checkPredicate('Array', [1, 2, 3])`
    */
   checkPredicate (name: string, input: any): boolean {
     const predicate = this.getPredicate(name);
@@ -511,8 +513,10 @@ export default class TypeContext {
 
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {
     // @flowIssue 252
-    const typeParameters = subject[TypeParametersSymbol];
-    if (typeParameters) {
+    const typeParametersPointer = subject[TypeParametersSymbol];
+
+    if (typeParametersPointer) {
+      const typeParameters = subject[typeParametersPointer];
       const keys = Object.keys(typeParameters);
       const length = Math.min(keys.length, typeInstances.length);
       for (let i = 0; i < length; i++) {

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -506,9 +506,7 @@ export default class TypeContext {
   }
 
   flowInto <T> (typeParameter: TypeParameter<T>): FlowIntoType<T> {
-    const target = new FlowIntoType(this);
-    target.typeParameter = typeParameter;
-    return target;
+    return flowIntoTypeParameter(typeParameter);
   }
 
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {

--- a/packages/flow-runtime/src/Validation.js
+++ b/packages/flow-runtime/src/Validation.js
@@ -17,7 +17,7 @@ export type ValidationJSON<T> = {
   }>
 };
 
-const validIdentifier = /^[$A-Z_][0-9A-Z_$]*$/i;
+const validIdentifierOrAccessor = /^[$A-Z_][0-9A-Z_$[\].]*$/i;
 
 export default class Validation<T> {
 
@@ -97,7 +97,7 @@ export function stringifyPath (path: IdentifierPath): string {
     if (part === '[[Return Type]]') {
       parts[i] = 'Return Type';
     }
-    else if (typeof part !== 'string' || !validIdentifier.test(part)) {
+    else if (typeof part !== 'string' || !validIdentifierOrAccessor.test(part)) {
       parts[i] = `[${String(part)}]`;
     }
     else if (i > 0) {

--- a/packages/flow-runtime/src/Validation.js
+++ b/packages/flow-runtime/src/Validation.js
@@ -25,7 +25,9 @@ export default class Validation<T> {
 
   input: T;
 
-  inputName: string = '';
+  path: string[] = [];
+
+  prefix: string = '';
 
   errors: ErrorTuple[] = [];
 

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithDefaultProps.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithDefaultProps.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+
+  class Point {
+    @t.decorate(t.number())
+    x: any = 0;
+
+    @t.decorate(t.number())
+    y: any = 0;
+  }
+
+  const point = new Point();
+  point.x = 123;
+  point.y = 456;
+
+  return point;
+}
+
+
+export function fail (t: TypeContext) {
+
+  class Point {
+    @t.decorate(t.number())
+    x: any = 123;
+
+    @t.decorate(t.number())
+    y: any = 'nope';
+  }
+
+  const point = new Point();
+
+  console.log(point.x, point.y);
+
+  return point;
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithProps.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithProps.js
@@ -1,0 +1,38 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+
+  class Point {
+    @t.decorate(t.number())
+    x: any;
+
+    @t.decorate(t.number())
+    y: any;
+  }
+
+  const point = new Point();
+  point.x = 123;
+  point.y = 456;
+
+  return point;
+}
+
+
+export function fail (t: TypeContext) {
+
+  class Point {
+    @t.decorate(t.number())
+    x: any;
+
+    @t.decorate(t.number())
+    y: any;
+  }
+
+  const point = new Point();
+  point.x = 123;
+  point.y = 'nope';
+
+  return point;
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithTypeParameters.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/simplestClassWithTypeParameters.js
@@ -1,0 +1,80 @@
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
+  class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    x = 0;
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    y = 0;
+
+    constructor(x, y) {
+      this[_PointTypeParametersSymbol] = {
+        T: t.typeParameter("T")
+      };
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      t.param("x", _xType).assert(x);
+      t.param("y", _yType).assert(y);
+      this.x = x;
+      this.y = y;
+    }
+
+    go () {
+      const _returnType = t.return(this[_PointTypeParametersSymbol].T);
+      return _returnType.assert(this.y);
+    }
+  }
+
+  const p = new Point(123, true);
+  return p.go();
+}
+
+
+export function fail (t: TypeContext) {
+
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
+  class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    x = 0;
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    y = 0;
+
+    constructor(x, y) {
+      this[_PointTypeParametersSymbol] = {
+        T: t.typeParameter("T")
+      };
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      t.param("x", _xType).assert(x);
+      t.param("y", _yType).assert(y);
+      this.x = x;
+      this.y = y;
+    }
+
+    go () {
+      const _returnType = t.return(this[_PointTypeParametersSymbol].T);
+      return _returnType.assert('nope this fails');
+    }
+  }
+
+  const p = new Point(123, true);
+  return p.go();
+}

--- a/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/typeParametersWithInheritance.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/ClassDeclaration/typeParametersWithInheritance.js
@@ -1,0 +1,81 @@
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  const {MixedPoint} = makeClasses(t);
+
+  const point = new MixedPoint([10, true]);
+  return point.pass();
+}
+
+export function fail (t: TypeContext) {
+  const {MixedPoint} = makeClasses(t);
+
+  const point = new MixedPoint([10, true]);
+  return point.fail();
+}
+
+function makeClasses (t: TypeContext) {
+  const _PointTypeParametersSymbol = Symbol("PointTypeParameters");
+
+  class Point {
+
+    static [t.TypeParametersSymbol] = _PointTypeParametersSymbol;
+
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    x = 0;
+    @t.decorate(function () {
+      return t.flowInto(this[_PointTypeParametersSymbol].T);
+    })
+    y = 0;
+
+    constructor(x, y) {
+      this[_PointTypeParametersSymbol] = {
+        T: t.typeParameter("T")
+      };
+      let _xType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      let _yType = t.flowInto(this[_PointTypeParametersSymbol].T);
+      t.param("x", _xType).assert(x);
+      t.param("y", _yType).assert(y);
+      this.x = x;
+      this.y = y;
+    }
+  }
+
+  const _MixedPointTypeParametersSymbol = Symbol("MixedPointTypeParameters");
+
+  class MixedPoint extends Point {
+    static [t.TypeParametersSymbol] = _MixedPointTypeParametersSymbol;
+
+    constructor([x, y]) {
+      const _typeParameters3 = {
+        F: t.typeParameter("F")
+      };
+      t.param(
+        "arguments[0]",
+        t.tuple(
+          t.flowInto(_typeParameters3.F),
+          t.flowInto(_typeParameters3.F)
+        )
+      ).assert(arguments[0]);
+
+      super(x, y);
+      this[_MixedPointTypeParametersSymbol] = _typeParameters3;
+      t.bindTypeParameters(this, this[_MixedPointTypeParametersSymbol].F);
+    }
+
+    pass () {
+      const _returnType = t.return(this[_MixedPointTypeParametersSymbol].F);
+      _returnType.assert(this.x);
+      return _returnType.assert(this.y);
+    }
+
+    fail () {
+       const _returnType = t.return(this[_MixedPointTypeParametersSymbol].F);
+      return _returnType.assert('bad. this is bad');
+    }
+  }
+
+  return {Point, MixedPoint};
+}

--- a/packages/flow-runtime/src/annotateValue.js
+++ b/packages/flow-runtime/src/annotateValue.js
@@ -1,0 +1,24 @@
+/* @flow */
+
+import Type from './types/Type';
+
+import {TypeSymbol} from './symbols';
+
+export type Decorator<T> = (input: T) => T;
+
+declare function annotateValue <T> (type: Type<T>): Decorator<T>;
+declare function annotateValue <T> (input: T, type: Type<T>): T; // eslint-disable-line no-redeclare
+
+export default function annotateValue (input, type?) { // eslint-disable-line no-redeclare
+  if (type instanceof Type) {
+    input[TypeSymbol] = type;
+    return input;
+  }
+  else {
+    const type = input;
+    return (input) => {
+      input[TypeSymbol] = type;
+      return input;
+    };
+  }
+}

--- a/packages/flow-runtime/src/classDecorators.js
+++ b/packages/flow-runtime/src/classDecorators.js
@@ -1,0 +1,127 @@
+/* @flow */
+
+import type Type from './types/Type';
+
+type ValueDescriptor<T> = {
+  writable: boolean;
+  initializer?: () => T;
+  enumerable: boolean;
+  configurable: boolean;
+};
+
+type AccessorDescriptor<T> = {
+  get: () => ? T;
+  set: (value: T) => void;
+  enumerable: boolean;
+  configurable: boolean;
+};
+
+export type Descriptor<T>
+ = AccessorDescriptor<T>
+ | ValueDescriptor<T>
+ ;
+
+type TypeSource<T>
+ = (() => Type<T>)
+ | Type<T>
+ ;
+
+export function makePropertyDescriptor <O: {} | Function, T> (typeSource: TypeSource<T>, input: O, propertyName: string, descriptor: Descriptor<T>): ? Descriptor<T> {
+  if (typeof descriptor.get === 'function' && typeof descriptor.set === 'function') {
+    return augmentExistingAccessors(typeSource, input, propertyName, (descriptor: $FlowIssue<AccessorDescriptor<T>>));
+  }
+  else {
+    return propertyToAccessor(typeSource, input, propertyName, (descriptor: $FlowIssue<ValueDescriptor<T>>));
+  }
+}
+
+function makePropertyName (name: string): string {
+  return `_flowRuntime$${name}`;
+}
+
+function getClassName (input: Function | Object): string {
+  if (typeof input === 'function') {
+    return input.name || '[Class anonymous]';
+  }
+  else if (typeof input.constructor === 'function') {
+    return getClassName(input.constructor);
+  }
+  else {
+    return '[Class anonymous]';
+  }
+}
+
+function resolveType <T> (receiver: any, typeSource: TypeSource<T>): Type<T> {
+  if (typeof typeSource === 'function') {
+    return typeSource.call(receiver);
+  }
+  else {
+    return typeSource;
+  }
+}
+
+function propertyToAccessor <O: {}, T> (typeSource: TypeSource<T>, input: O, propertyName: string, descriptor: ValueDescriptor<T>): AccessorDescriptor<T> {
+  const safeName = makePropertyName(propertyName);
+  const className = getClassName(input);
+  const {initializer, writable, ...config} = descriptor; // eslint-disable-line no-unused-vars
+
+  const propertyPath = [className, propertyName];
+
+  return {
+    ...config,
+    type: 'accessor',
+    get (): ? T {
+      if (safeName in this) {
+        return (this: any)[safeName];
+      }
+      else if (initializer) {
+        const type = resolveType(this, typeSource);
+        const value = initializer.call(this);
+        const context = type.context;
+        context.assert(type, value, 'Default value for property', propertyPath);
+        Object.defineProperty(this, safeName, {
+          writable: true,
+          value: value
+        });
+        return value;
+      }
+      else {
+        Object.defineProperty(this, safeName, {
+          writable: true,
+          value: undefined
+        });
+      }
+    },
+    set (value: T): void {
+      const type = resolveType(this, typeSource);
+      const context = type.context;
+      context.assert(type, value, 'Property', propertyPath);
+      if (safeName in this) {
+        this[safeName] = value;
+      }
+      else {
+        Object.defineProperty(this, safeName, {
+          writable: true,
+          value: value
+        });
+      }
+    }
+  };
+}
+
+function augmentExistingAccessors <O: {}, T> (typeSource: TypeSource<T>, input: O, propertyName: string, descriptor: AccessorDescriptor<T>) {
+
+  const className = getClassName(input);
+  const propertyPath = [className, propertyName];
+
+  const originalSetter = descriptor.set;
+
+  descriptor.set = function set (value: T): void {
+    const type = resolveType(this, typeSource);
+    const context = type.context;
+    context.assert(type, value, 'Property', propertyPath);
+    originalSetter.call(this, value);
+  };
+
+}
+

--- a/packages/flow-runtime/src/classDecorators.js
+++ b/packages/flow-runtime/src/classDecorators.js
@@ -78,7 +78,7 @@ function propertyToAccessor <O: {}, T> (typeSource: TypeSource<T>, input: O, pro
         const type = resolveType(this, typeSource);
         const value = initializer.call(this);
         const context = type.context;
-        context.assert(type, value, 'Default value for property', propertyPath);
+        context.check(type, value, 'Default value for property', propertyPath);
         Object.defineProperty(this, safeName, {
           writable: true,
           value: value
@@ -95,7 +95,7 @@ function propertyToAccessor <O: {}, T> (typeSource: TypeSource<T>, input: O, pro
     set (value: T): void {
       const type = resolveType(this, typeSource);
       const context = type.context;
-      context.assert(type, value, 'Property', propertyPath);
+      context.check(type, value, 'Property', propertyPath);
       if (safeName in this) {
         this[safeName] = value;
       }
@@ -119,7 +119,7 @@ function augmentExistingAccessors <O: {}, T> (typeSource: TypeSource<T>, input: 
   descriptor.set = function set (value: T): void {
     const type = resolveType(this, typeSource);
     const context = type.context;
-    context.assert(type, value, 'Property', propertyPath);
+    context.check(type, value, 'Property', propertyPath);
     originalSetter.call(this, value);
   };
 

--- a/packages/flow-runtime/src/declarations/ClassDeclaration.js
+++ b/packages/flow-runtime/src/declarations/ClassDeclaration.js
@@ -82,6 +82,6 @@ export default class ClassDeclaration<O: {}> extends Declaration {
   toString (withDeclaration?: boolean) {
     const {name, superClass, body} = this;
     const superClassName = superClass && ((typeof superClass.name === 'string' && superClass.name) || superClass.toString());
-    return `${withDeclaration ? 'declare ' : ''}class ${name}${superClassName ? `extends ${superClassName} ` : ''} ${body.toString()}`;
+    return `${withDeclaration ? 'declare ' : ''}class ${name}${superClassName ? ` extends ${superClassName}` : ''} ${body.toString()}`;
   }
 }

--- a/packages/flow-runtime/src/declarations/ExtendsDeclaration.js
+++ b/packages/flow-runtime/src/declarations/ExtendsDeclaration.js
@@ -18,4 +18,14 @@ export default class ExtendsDeclaration<T> extends Declaration {
   unwrap () {
     return this.type.unwrap();
   }
+
+  toString (withDeclaration?: boolean) {
+    const {type} = this;
+    if (withDeclaration) {
+      return `extends ${type.toString()}`;
+    }
+    else {
+      return type.toString();
+    }
+  }
 }

--- a/packages/flow-runtime/src/errorReporting/__tests__/makeJSONError.test.js
+++ b/packages/flow-runtime/src/errorReporting/__tests__/makeJSONError.test.js
@@ -119,7 +119,7 @@ describe('makeJSONError', () => {
 
     it('should reject an invalid value', () => {
       const validation = t.validate(type, [{items: [1, 2, 3]}, {items: [1, 2, "foo"]}]);
-      validation.inputName = 'input';
+      validation.path = ['input'];
       const report = makeJSONError(validation);
       expect(report, [
         'input[1].items[2] must be a number, got string'
@@ -151,7 +151,7 @@ describe('makeJSONError', () => {
 
     it('should reject an invalid value', () => {
       const validation = t.validate(type, invalid);
-      validation.inputName = 'input';
+      validation.path = ['input'];
       const report = makeJSONError(validation);
       expect(report, [
         'input argument "b" must be: number, got (a: number) => number'

--- a/packages/flow-runtime/src/errorReporting/makeJSONError.js
+++ b/packages/flow-runtime/src/errorReporting/makeJSONError.js
@@ -12,7 +12,7 @@ export default function makeJSONError <T> (validation: Validation<T>) {
   for (const [path, message, expectedType] of validation.errors) {
     const expected = expectedType ? expectedType.toString() : null;
     const actual = context.typeOf(resolvePath(input, path)).toString();
-    const field = stringifyPath(validation.inputName ? [validation.inputName].concat(path) : path);
+    const field = stringifyPath(validation.path.concat(path));
 
     const pointer = `/${path.join('/')}`;
 

--- a/packages/flow-runtime/src/errorReporting/makeTypeError.js
+++ b/packages/flow-runtime/src/errorReporting/makeTypeError.js
@@ -11,19 +11,23 @@ export default function makeTypeError <T> (validation: Validation<T>) {
   if (!validation.hasErrors()) {
     return;
   }
-  const {input, context} = validation;
+  const {prefix, input, context} = validation;
   const collected = [];
   for (const [path, message, expectedType] of validation.errors) {
     const expected = expectedType ? expectedType.toString() : "*";
     const actual = context.typeOf(resolvePath(input, path)).toString();
 
-    const field = stringifyPath(validation.inputName ? [validation.inputName].concat(path) : path);
+    const field = stringifyPath(validation.path.concat(path));
 
 
     collected.push(
       `${field} ${message}\n\nExpected: ${expected}\n\nActual: ${actual}\n`
     );
   }
-  const error = new RuntimeTypeError(collected.join(delimiter));
-  return error;
+  if (prefix) {
+    return new RuntimeTypeError(`${prefix.trim()} ${collected.join(delimiter)}`);
+  }
+  else {
+    return new RuntimeTypeError(collected.join(delimiter));
+  }
 }

--- a/packages/flow-runtime/src/errorReporting/makeWarningMessage.js
+++ b/packages/flow-runtime/src/errorReporting/makeWarningMessage.js
@@ -15,7 +15,7 @@ export default function makeWarningMessage <T> (validation: Validation<T>): ? st
     const expected = expectedType ? expectedType.toString() : "*";
     const actual = context.typeOf(resolvePath(input, path)).toString();
 
-    const field = stringifyPath(validation.inputName ? [validation.inputName].concat(path) : path);
+    const field = stringifyPath(validation.path.concat(path));
 
 
     collected.push(

--- a/packages/flow-runtime/src/makeUnion.js
+++ b/packages/flow-runtime/src/makeUnion.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+import UnionType from './types/UnionType';
+import type TypeContext from './TypeContext';
+import type Type from './types/Type';
+
+export default function makeUnion <T> (context: TypeContext, types: Type<T>[]): UnionType<T> {
+  const length = types.length;
+  const merged = [];
+  for (let i = 0; i < length; i++) {
+    const type = types[i];
+    if (type instanceof UnionType) {
+      mergeUnionTypes(merged, type.types);
+    }
+    else {
+      merged.push(type);
+    }
+  }
+  const union = new UnionType(context);
+  union.types = merged;
+  return union;
+}
+
+function mergeUnionTypes (aTypes: Type<any>[], bTypes: Type<any>[]): void {
+  loop: for (let i = 0; i < bTypes.length; i++) {
+    const bType = bTypes[i];
+    for (let j = 0; j < aTypes.length; j++) {
+      const aType = aTypes[j];
+      if (aType.acceptsType(bType)) {
+        continue loop;
+      }
+    }
+    aTypes.push(bType);
+  }
+}

--- a/packages/flow-runtime/src/symbols.js
+++ b/packages/flow-runtime/src/symbols.js
@@ -10,5 +10,4 @@ export const TraverseValueSymbol = Symbol('TraverseValue');
 export const TraverseTypeSymbol = Symbol('TraverseType');
 export const TypeSymbol = Symbol('Type');
 export const TypeParametersSymbol = Symbol('TypeParameters');
-export const TypeParameterStatusSymbol = Symbol('TypeParameterStatus');
 export const TypePredicateRegistrySymbol = Symbol('TypePredicateRegistry');

--- a/packages/flow-runtime/src/types/FlowIntoType.js
+++ b/packages/flow-runtime/src/types/FlowIntoType.js
@@ -11,7 +11,7 @@ import TypeParameter from './TypeParameter';
  * A virtual type which allows types it receives to "flow" upwards into a type parameter.
  * The type parameter will become of a union of any types seen by this instance.
  */
-export default class FlowIntoType<T> extends Type {
+export default class FlowIntoType<T: any> extends Type {
   typeName: string = 'FlowIntoType';
 
   typeParameter: TypeParameter<T>;

--- a/packages/flow-runtime/src/types/ObjectTypeProperty.js
+++ b/packages/flow-runtime/src/types/ObjectTypeProperty.js
@@ -12,6 +12,8 @@ export default class ObjectTypeProperty<K: string | number, V> extends Type {
   key: K;
   value: Type<V>;
   optional: boolean;
+  // @flowIgnore
+  'static': boolean;
   constraints: TypeConstraint[] = [];
 
   addConstraint (...constraints: TypeConstraint[]): ObjectTypeProperty<K, V> {
@@ -58,7 +60,12 @@ export default class ObjectTypeProperty<K: string | number, V> extends Type {
   }
 
   toString (): string {
-    return `${this.key}${this.optional ? '?' : ''}: ${this.value.toString()};`;
+    if (this.static) {
+      return `static ${this.key}${this.optional ? '?' : ''}: ${this.value.toString()};`;
+    }
+    else {
+      return `${this.key}${this.optional ? '?' : ''}: ${this.value.toString()};`;
+    }
   }
 
   toJSON () {

--- a/packages/flow-runtime/src/types/ParameterizedFunctionType.js
+++ b/packages/flow-runtime/src/types/ParameterizedFunctionType.js
@@ -64,7 +64,7 @@ export default class ParameterizedFunctionType <X, P: any, R: any> extends Type 
   /**
    * Get the inner type or value.
    */
-  unwrap (...typeInstances: Type<any>[]): Type<(...params: P[]) => R> {
+  unwrap (...typeInstances: Type<any>[]): Type<(...params: P[]) => R | mixed> {
     return getPartial(this, ...typeInstances).unwrap();
   }
 

--- a/packages/flow-runtime/src/types/TypeParameter.js
+++ b/packages/flow-runtime/src/types/TypeParameter.js
@@ -5,6 +5,8 @@ import type Validation, {IdentifierPath} from '../Validation';
 
 import FlowIntoType from './FlowIntoType';
 
+const FlowIntoSymbol = Symbol('FlowInto');
+
 /**
  * # TypeParameter
  *
@@ -18,6 +20,9 @@ export default class TypeParameter<T> extends Type {
   bound: ? Type<T>;
 
   recorded: ? Type<T>;
+
+  // @flowIssue 252
+  [FlowIntoSymbol]: ? FlowIntoType = null;
 
 
   collectErrors (validation: Validation<any>, path: IdentifierPath, input: any): boolean {
@@ -118,4 +123,16 @@ export default class TypeParameter<T> extends Type {
       recorded: this.recorded
     };
   }
+}
+
+export function flowIntoTypeParameter <T> (typeParameter: TypeParameter<T>): FlowIntoType<T> {
+  const existing: ? FlowIntoType<T> = (typeParameter: $FlowIssue<252>)[FlowIntoSymbol];
+  if (existing) {
+    return existing;
+  }
+
+  const target = new FlowIntoType(typeParameter.context);
+  target.typeParameter = typeParameter;
+  (typeParameter: $FlowIssue<252>)[FlowIntoSymbol] = target;
+  return target;
 }


### PR DESCRIPTION
Also renames the `decorate` plugin option to `annotate` to hopefully reduce confusion.

fixes #22