### PR TITLE
Fix invalid references to `arguments` in shadowed arrow functions

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/47-arguments-hoisting.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/bugs/47-arguments-hoisting.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+export const input = `
+type Person = {
+  name: string
+};
+
+let sayHello = ({ name } : Person) => {
+  sayHello(name);
+}
+
+sayHello({ name: "Kermit" });
+`;
+
+export const expected = `
+import t from "flow-runtime";
+const Person = t.type("Person", t.object(
+  t.property("name", t.string())
+));
+
+let sayHello = function ({ name }) {
+  t.param("arguments[0]", Person).assert(arguments[0]);
+  sayHello(name);
+};
+
+sayHello({ name: "Kermit" });
+`;

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -371,11 +371,17 @@ export default function transformVisitors (context: ConversionContext): Object {
             args.push(t.booleanLiteral(true));
           }
 
-          const ref = t.memberExpression(
-            t.identifier('arguments'),
-            t.numericLiteral(argumentIndex),
-            true
-          );
+          // OMG This is disgusting:
+          // We want to retain a reference to arguments in what was an
+          // arrow function that has been turned into a normal
+          // function expression. The problem is that babel will see
+          // our reference to `arguments` and assume we are talking about
+          // the `arguments` of an outer function because arrow functions
+          // don't have `arguments`. To get around this we make an identifier
+          // with the name `arguments[0]` which is not valid but will survive
+          // all the way through to code generation, and produce a valid node
+          // at the end.
+          const ref = t.identifier(`arguments[${argumentIndex}]`);
 
           const expression = t.expressionStatement(
             context.assert(


### PR DESCRIPTION
Maybe this is a babel bug but could argue that it's intentional - we expand `ArrowFunctionExpression`s into `FunctionExpression` when encountering object or array patterns in function type parameters so that we can reference `arguments`, however babel thinks we're still in an arrow so it produces an invalid reference. There's a proper way to fix this but it's quite invasive - we'd need to unroll all the subsequent parameters after an `ObjectPattern` or `ArrayPattern` in a function parameter into the function body itself. This is the quicker, less nice fix.