### PR TITLE
npm ignore source files for flow-runtime

### DIFF
--- a/packages/flow-runtime/.npmignore
+++ b/packages/flow-runtime/.npmignore
@@ -5,3 +5,9 @@ coverage
 .DS_Store
 .env
 npm-debug.log
+
+# files that require their own .flowconfig
+/config
+/flow-typed
+/src
+/test


### PR DESCRIPTION
This is necessary so that packages can be published to npm using flow-runtime, and then consumers of those packages can use flow.  Otherwise consumers of the package have to ignore flow-runtime in their flowconfig.