### PR TITLE
feat: support shorthand import type

### DIFF
--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -41,7 +41,7 @@
     "babel-generator": "^6.21.0",
     "babel-traverse": "^6.20.0",
     "babel-types": "^6.16.0",
-    "babylon": "^6.14.1",
+    "babylon": "^6.16.1",
     "camelcase": "^3.0.0",
     "flow-config-parser": "^0.3.0"
   },

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/shorthandImportType.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/shorthandImportType.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+export const input = `
+  import { type Demo } from './simplestExportType';
+
+  type Local = number;
+
+  type Item = {
+    local: Local;
+    value: Demo;
+  };
+`;
+
+export const expected = `
+  import { Demo as _Demo } from './simplestExportType';
+  import t from "flow-runtime";
+  const Demo = t.tdz(() => _Demo);
+
+  const Local = t.type("Local", t.number());
+
+  const Item = t.type("Item", t.object(
+    t.property("local", Local),
+    t.property("value", t.ref(Demo))
+  ));
+`;


### PR DESCRIPTION
Thank you for the lib,

This PR adds the support of shorthand import type :

```js
import { type PersonType } from './types';
```



