### PR TITLE
publish on npm with source files

### DIFF
--- a/packages/flow-runtime/.npmignore
+++ b/packages/flow-runtime/.npmignore
@@ -9,5 +9,4 @@ npm-debug.log
 # files that require their own .flowconfig
 /config
 /flow-typed
-/src
 /test


### PR DESCRIPTION
remove `flow-runtime` src in .npmignore, because it is referenced in the `.map` in the dist directory and can be used by tools to display the correct line.
Another solution is to remove the `.map`