### PR TITLE
Use transform-runtime to fix regenerator issues

### DIFF
--- a/packages/flow-runtime/config/rollup.config.browser.js
+++ b/packages/flow-runtime/config/rollup.config.browser.js
@@ -22,6 +22,12 @@ export default {
       ],
       plugins: [
         'transform-decorators-legacy',
+        ['transform-runtime', {
+          helpers: false,
+          polyfill: false,
+          regenerator: true,
+          moduleName: 'rollup-regenerator-runtime'
+        }],
         'external-helpers'
       ]
     }),

--- a/packages/flow-runtime/package.json
+++ b/packages/flow-runtime/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-external-helpers": "^6.18.0",
     "babel-plugin-flow-runtime": "^0.10.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.1.4",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-es2015-node": "^6.1.1",
@@ -44,6 +45,7 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-uglify": "^1.0.1",
+    "rollup-regenerator-runtime": "^6.23.1",
     "uglify-js": "git://github.com/mishoo/UglifyJS2.git#harmony"
   },
   "eslintConfig": {

--- a/packages/flow-runtime/yarn.lock
+++ b/packages/flow-runtime/yarn.lock
@@ -718,6 +718,12 @@ babel-plugin-transform-regenerator@^6.16.0, babel-plugin-transform-regenerator@^
   dependencies:
     regenerator-transform "0.9.8"
 
+babel-plugin-transform-runtime:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-strict-mode@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz#df7cf2991fe046f44163dcd110d5ca43bc652b9d"
@@ -871,6 +877,13 @@ babel-register@^6.18.0:
 babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -2672,6 +2685,12 @@ rollup-pluginutils@^1.5.0:
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-regenerator-runtime@^6.23.1:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/rollup-regenerator-runtime/-/rollup-regenerator-runtime-6.23.1.tgz#fd2bbb675fe093351243e872873a281dada6bcb6"
+  dependencies:
+    regenerator-runtime "^0.10.0"
 
 rollup@^0.41.4:
   version "0.41.4"


### PR DESCRIPTION
This uses babel-plugin-transform-runtime to add the helpers needed for regenerator.  It uses regenerator-runtime, which does not pollute the global scope.

[closes #35]