### PR TITLE
relax Class<T> rules for now

### DIFF
--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -190,6 +190,10 @@ export default class TypeContext {
   // @flowIssue 252
   [CurrentModuleSymbol]: ? ModuleDeclaration;
 
+  get TypeParametersSymbol (): typeof TypeParametersSymbol {
+    return TypeParametersSymbol;
+  }
+
 
   makeJSONError <T> (validation: Validation<T>): ? Array<Object> {
     return makeJSONError(validation);
@@ -605,7 +609,6 @@ export default class TypeContext {
    * Bind the type parameters for the parent class of the given instance.
    */
   bindTypeParameters <T: {}> (subject: T, ...typeInstances: Type<any>[]): T {
-
     const instancePrototype = Object.getPrototypeOf(subject);
     // @flowIssue
     const parentPrototype = instancePrototype && Object.getPrototypeOf(instancePrototype);

--- a/packages/flow-runtime/src/TypeContext.js
+++ b/packages/flow-runtime/src/TypeContext.js
@@ -890,7 +890,7 @@ export default class TypeContext {
     return target;
   }
 
-  union <T> (...types: Type<T>[]): UnionType<T> {
+  union <T> (...types: Type<T>[]): Type<T> {
     return makeUnion(this, types);
   }
 

--- a/packages/flow-runtime/src/__tests__/__fixtures__/bugs/79-generic-class.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/bugs/79-generic-class.js
@@ -1,0 +1,52 @@
+/* @flow */
+
+import type TypeContext from '../../../TypeContext';
+
+export function pass (t: TypeContext) {
+  const _ContainerTypeParametersSymbol = Symbol("ContainerTypeParameters");
+
+  @t.annotate(
+    t.class("Container", Container => {
+      const T = Container.typeParameter("T");
+      return [t.method("constructor", t.param("value", t.flowInto(T)))];
+    })
+  )
+  class Container {
+    value: any;
+    // @flowIgnore
+    static [t.TypeParametersSymbol] = _ContainerTypeParametersSymbol;
+
+    constructor(value) {
+      // @flowIgnore
+      this[_ContainerTypeParametersSymbol] = {
+        T: t.typeParameter("T")
+      };
+
+      // @flowIgnore
+      let _valueType = t.flowInto(this[_ContainerTypeParametersSymbol].T);
+
+      t.param("value", _valueType).assert(value);
+
+      this.value = value;
+    }
+  }
+
+  @t.annotate(
+    t.class(
+      "StringContainer",
+      t.extends(Container, t.string()),
+      t.method("constructor", t.rest("args", t.any()))
+    )
+  )
+  class StringContainer extends Container {
+    constructor(...args) {
+      super(...args);
+      t.bindTypeParameters(this, t.string());
+    }
+  }
+
+  const Klazz = t.Class(t.ref(Container, t.string())).assert(StringContainer);
+
+  return Klazz;
+}
+

--- a/packages/flow-runtime/src/compareTypes.js
+++ b/packages/flow-runtime/src/compareTypes.js
@@ -23,6 +23,8 @@ import {
  */
 export default function compareTypes (a: Type<any>, b: Type<any>): -1 | 0 | 1 {
 
+  let result;
+
   if (a === b) {
     return 0;
   }
@@ -32,16 +34,24 @@ export default function compareTypes (a: Type<any>, b: Type<any>): -1 | 0 | 1 {
   }
 
   if (a instanceof TypeAlias) {
-    return a.compareWith(b);
+    result = a.compareWith(b);
   }
-
-  if (a instanceof FlowIntoType || a instanceof TypeParameter || b instanceof FlowIntoType) {
-    return a.compareWith(b);
+  else if (a instanceof FlowIntoType || a instanceof TypeParameter || b instanceof FlowIntoType) {
+    result = a.compareWith(b);
   }
   else if (a instanceof AnyType || a instanceof ExistentialType || a instanceof MixedType) {
     return 1;
   }
   else {
-    return a.compareWith(b);
+    result = a.compareWith(b);
+  }
+
+  if (b instanceof AnyType) {
+    // Note: This check cannot be moved higher in the scope,
+    // as this would prevent types from being propagated upwards.
+    return 1;
+  }
+  else {
+    return result;
   }
 }

--- a/packages/flow-runtime/src/flowTypes/ClassType.js
+++ b/packages/flow-runtime/src/flowTypes/ClassType.js
@@ -2,76 +2,65 @@
 
 import Type from '../types/Type';
 import GenericType from '../types/GenericType';
-import ClassDeclaration from '../declarations/ClassDeclaration';
-import TypeParameterApplication from '../types/TypeParameterApplication';
 import getErrorMessage from '../getErrorMessage';
 import compareTypes from '../compareTypes';
 
+import type TypeContext from '../TypeContext';
 
 import type Validation, {ErrorTuple, IdentifierPath} from '../Validation';
+
+function checkGenericType (context: TypeContext, expected: GenericType, input: Function) {
+  const {impl} = expected;
+  if (typeof impl !== 'function') {
+    // There is little else we can do here, so accept anything.
+    return true;
+  }
+  else if (impl === input || impl.isPrototypeOf(input)) {
+    return true;
+  }
+
+  const annotation = context.getAnnotation(impl);
+  if (annotation == null) {
+    return false;
+  }
+  else {
+    return checkType(context, annotation, input);
+  }
+}
+
+function checkType (context: TypeContext, expected: Type<*>, input: Function) {
+  const annotation = context.getAnnotation(input);
+  if (annotation != null) {
+    const result = compareTypes(expected, annotation);
+    return result !== -1;
+  }
+  return true;
+}
+
 
 export default class ClassType<T> extends Type {
   typeName: string = 'ClassType';
 
-  instanceType: Type<T>;
+  instanceType: Type<*>;
 
   *errors (validation: Validation<any>, path: IdentifierPath, input: any): Generator<ErrorTuple, void, void> {
 
     const {instanceType, context} = this;
     if (typeof input !== 'function') {
       yield [path, getErrorMessage('ERR_EXPECT_CLASS', instanceType.toString()), this];
-    }
-    const expectedType = instanceType.unwrap();
-    if (expectedType instanceof GenericType && typeof expectedType.impl === 'function') {
-      if (input === expectedType.impl) {
-        return;
-      }
-      else if (expectedType.impl.prototype.isPrototypeOf(input.prototype)) {
-        return;
-      }
-      else {
-        yield [path, getErrorMessage('ERR_EXPECT_CLASS', instanceType.toString()), this];
-        return;
-      }
-    }
-    let annotation = context.getAnnotation(input);
-    if (annotation) {
-      annotation = annotation.unwrap();
-      if (!expectedType.acceptsType(annotation)) {
-        const acceptsInstance = (
-             annotation instanceof ClassDeclaration
-          && expectedType.acceptsType(annotation.body)
-        );
-
-        if (!acceptsInstance) {
-          yield [path, getErrorMessage('ERR_EXPECT_CLASS', instanceType.toString()), this];
-        }
-      }
       return;
     }
-    let matches;
-    // we're dealing with a type
-    switch (input.typeName) {
-      case 'NumberType':
-      case 'NumericLiteralType':
-        matches = input === Number;
-        break;
-      case 'BooleanType':
-      case 'BooleanLiteralType':
-        matches = input === Boolean;
-        break;
-      case 'StringType':
-      case 'StringLiteralType':
-        matches = input === String;
-        break;
-      case 'ArrayType':
-      case 'TupleType':
-        matches = input === Array;
-        break;
-      default:
-        return;
-    }
-    if (!matches) {
+    const expectedType = (
+      instanceType.typeName === 'ClassDeclaration'
+      ? instanceType
+      : instanceType.unwrap()
+    );
+    const isValid = (
+      expectedType instanceof GenericType
+      ? checkGenericType(context, expectedType, input)
+      : checkType(context, expectedType, input)
+    );
+    if (!isValid) {
       yield [path, getErrorMessage('ERR_EXPECT_CLASS', instanceType.toString()), this];
     }
   }
@@ -79,58 +68,19 @@ export default class ClassType<T> extends Type {
   accepts (input: any): boolean {
     const {instanceType, context} = this;
     if (typeof input !== 'function') {
-        return false;
-      }
-      let expectedType = instanceType.unwrap();
-      if (expectedType instanceof GenericType && typeof expectedType.impl === 'function') {
-        if (input === expectedType.impl) {
-          return true;
-        }
-        else if (typeof expectedType.impl === 'function') {
-          if (expectedType.impl.prototype.isPrototypeOf(input.prototype)) {
-            return true;
-          }
-          else {
-            return false;
-          }
-        }
-      }
-
-      const annotation = context.getAnnotation(input);
-
-      if (annotation) {
-        return expectedType.acceptsType(annotation);
-      }
-      else if (expectedType instanceof TypeParameterApplication) {
-        expectedType = expectedType.parent;
-      }
-
-      if (expectedType instanceof GenericType && typeof expectedType.impl === 'function') {
-        if (expectedType.impl.prototype.isPrototypeOf(input.prototype)) {
-          return true;
-        }
-        else {
-          return false;
-        }
-      }
-
-      // we're dealing with a type
-      switch (input.typeName) {
-        case 'NumberType':
-        case 'NumericLiteralType':
-          return input === Number;
-        case 'BooleanType':
-        case 'BooleanLiteralType':
-          return input === Boolean;
-        case 'StringType':
-        case 'StringLiteralType':
-          return input === String;
-        case 'ArrayType':
-        case 'TupleType':
-          return input === Array;
-        default:
-          return false;
-      }
+      return false;
+    }
+    const expectedType = (
+      instanceType.typeName === 'ClassDeclaration'
+      ? instanceType
+      : instanceType.unwrap()
+    );
+    if (expectedType instanceof GenericType) {
+      return checkGenericType(context, expectedType, input);
+    }
+    else {
+      return checkType(context, expectedType, input);
+    }
   }
 
   compareWith (input: Type<any>): -1 | 0 | 1 {

--- a/packages/flow-runtime/src/flowTypes/ClassType.js
+++ b/packages/flow-runtime/src/flowTypes/ClassType.js
@@ -16,6 +16,7 @@ export default class ClassType<T> extends Type {
   instanceType: Type<T>;
 
   *errors (validation: Validation<any>, path: IdentifierPath, input: any): Generator<ErrorTuple, void, void> {
+
     const {instanceType, context} = this;
     if (typeof input !== 'function') {
       yield [path, getErrorMessage('ERR_EXPECT_CLASS', instanceType.toString()), this];
@@ -33,10 +34,10 @@ export default class ClassType<T> extends Type {
         return;
       }
     }
-    const annotation = context.getAnnotation(input);
+    let annotation = context.getAnnotation(input);
     if (annotation) {
+      annotation = annotation.unwrap();
       if (!expectedType.acceptsType(annotation)) {
-
         const acceptsInstance = (
              annotation instanceof ClassDeclaration
           && expectedType.acceptsType(annotation.body)

--- a/packages/flow-runtime/src/index.cjs.js
+++ b/packages/flow-runtime/src/index.cjs.js
@@ -60,10 +60,6 @@ import {
   ExtendsDeclaration
 } from './declarations';
 
-import {
-  TypeParametersSymbol
-} from './symbols';
-
 import TypeContext from './TypeContext';
 
 function defineProperty (name: string, value: any) {
@@ -72,7 +68,6 @@ function defineProperty (name: string, value: any) {
   });
 }
 
-defineProperty('TypeParametersSymbol', TypeParametersSymbol);
 defineProperty('TypeContext', TypeContext);
 defineProperty('Type', Type);
 defineProperty('TypeBox', TypeBox);

--- a/packages/flow-runtime/src/makeUnion.js
+++ b/packages/flow-runtime/src/makeUnion.js
@@ -3,15 +3,22 @@
 import UnionType from './types/UnionType';
 import compareTypes from './compareTypes';
 
+import AnyType from './types/AnyType';
+import MixedType from './types/MixedType';
+import ExistentialType from './types/ExistentialType';
+
 import type TypeContext from './TypeContext';
 import type Type from './types/Type';
 
 
-export default function makeUnion <T> (context: TypeContext, types: Type<T>[]): UnionType<T> {
+export default function makeUnion <T> (context: TypeContext, types: Type<T>[]): Type<T> {
   const length = types.length;
   const merged = [];
   for (let i = 0; i < length; i++) {
     const type = types[i];
+    if (type instanceof AnyType || type instanceof MixedType || type instanceof ExistentialType) {
+      return (type: $FlowFixme);
+    }
     if (type instanceof UnionType) {
       mergeUnionTypes(merged, type.types);
     }

--- a/packages/flow-runtime/src/typed.test.js
+++ b/packages/flow-runtime/src/typed.test.js
@@ -1,9 +1,9 @@
 /* @flow */
-import {ok, throws} from 'assert';
+import {ok, equal, throws} from 'assert';
 
 import t from './globalContext';
 
-const no = (input: any): any => ok(!input);
+const no = (input: any): any => equal(Boolean(input), false);
 
 describe('Typed API', () => {
   it('should check a string', () => {
@@ -252,7 +252,8 @@ describe('Typed API', () => {
 
   it('should handle Class<User>', () => {
 
-    @t.decorate(t.object(
+    @t.annotate(t.class(
+      'User',
       t.property('id', t.number()),
       t.property('name', t.string()),
       t.property('email', t.string())
@@ -264,11 +265,13 @@ describe('Typed API', () => {
     }
 
 
+    @t.annotate(t.class('AdminUser', t.extends(User)))
     class AdminUser extends User {
 
     }
 
-    @t.decorate(t.object(
+    @t.annotate(t.class(
+      'Role',
       t.property('name', t.string()),
     ))
     class Role {
@@ -286,6 +289,7 @@ describe('Typed API', () => {
 
     const IUserClass = t.Class(t.ref(User));
     const IAdminUserClass = t.Class(t.ref(AdminUser));
+
     no(IUserClass.accepts(Role));
     ok(IUserClass.accepts(User));
     ok(IUserClass.accepts(AdminUser));

--- a/packages/flow-runtime/src/types/FunctionType.js
+++ b/packages/flow-runtime/src/types/FunctionType.js
@@ -117,12 +117,12 @@ export default class FunctionType<P, R> extends Type {
 
     const params = this.params;
     const inputParams = input.params;
-    if (inputParams.length < params.length) {
-      return -1;
-    }
     for (let i = 0; i < params.length; i++) {
       const param = params[i];
-      const inputParam = inputParams[i];
+      const inputParam = i >= inputParams.length ? input.rest : inputParams[i];
+      if (inputParam == null) {
+        return -1;
+      }
       const result = compareTypes(param, inputParam);
       if (result === -1) {
         return -1;

--- a/packages/flow-runtime/src/types/FunctionType.js
+++ b/packages/flow-runtime/src/types/FunctionType.js
@@ -27,6 +27,9 @@ export default class FunctionType<P, R> extends Type {
     const annotation = input[TypeSymbol];
     const {returnType, params} = this;
     if (annotation) {
+      if (!annotation.params) {
+        return;
+      }
       for (let i = 0; i < params.length; i++) {
         const param = params[i];
         const annotationParam = annotation.params[i];
@@ -72,6 +75,9 @@ export default class FunctionType<P, R> extends Type {
     const {returnType, params} = this;
     const annotation = input[TypeSymbol];
     if (annotation) {
+      if (!annotation.params) {
+        return true;
+      }
       for (let i = 0; i < params.length; i++) {
         const param = params[i];
         const annotationParam = annotation.params[i];

--- a/packages/flow-runtime/src/types/FunctionTypeParam.js
+++ b/packages/flow-runtime/src/types/FunctionTypeParam.js
@@ -4,6 +4,7 @@ import Type from './Type';
 import compareTypes from '../compareTypes';
 
 import type Validation, {ErrorTuple, IdentifierPath} from '../Validation';
+import FunctionTypeRestParam from './FunctionTypeRestParam';
 
 export default class FunctionTypeParam<T> extends Type {
   typeName: string = 'FunctionTypeParam';
@@ -32,7 +33,7 @@ export default class FunctionTypeParam<T> extends Type {
   }
 
   compareWith (input: Type<any>): -1 | 0 | 1 {
-    if (input instanceof FunctionTypeParam) {
+    if (input instanceof FunctionTypeParam || input instanceof FunctionTypeRestParam) {
       return compareTypes(this.type, input.type);
     }
     else {

--- a/packages/flow-runtime/src/types/GenericType.js
+++ b/packages/flow-runtime/src/types/GenericType.js
@@ -3,6 +3,7 @@
 import TypeConstructor from './TypeConstructor';
 
 import type Type from './Type';
+import compareTypes from '../compareTypes';
 
 import getErrorMessage from "../getErrorMessage";
 import type Validation, {ErrorTuple, IdentifierPath} from '../Validation';
@@ -12,22 +13,58 @@ export default class GenericType extends TypeConstructor {
   typeName: string = 'GenericType';
 
   *errors (validation: Validation<any>, path: IdentifierPath, input: any): Generator<ErrorTuple, void, void> {
-    const {name, impl} = this;
+    const {name, impl, context} = this;
     if (!(input instanceof impl)) {
-      yield [path, getErrorMessage('ERR_EXPECT_INSTANCEOF', name), this];
+      const annotation = context.getAnnotation(impl);
+      if (annotation) {
+        yield* annotation.errors(validation, path, input);
+      }
+      else {
+        yield [path, getErrorMessage('ERR_EXPECT_INSTANCEOF', name), this];
+      }
     }
   }
 
   accepts <P> (input: any, ...typeInstances: Type<P>[]): boolean {
-    return input instanceof this.impl;
+    const {context, impl} = this;
+    if (input instanceof impl) {
+      return true;
+    }
+    const annotation = context.getAnnotation(impl);
+    if (annotation) {
+      return annotation.accepts(input);
+    }
+    else {
+      return false;
+    }
   }
 
-  compareWith (input: Type<any>): -1 | 0 | 1 {
-    if (input instanceof GenericType && input.impl === this.impl) {
+  compareWith <P> (input: Type<any>, ...typeInstances: Type<P>[]): -1 | 0 | 1 {
+    const {context, impl} = this;
+    const annotation = context.getAnnotation(impl);
+    if (annotation) {
+      const expected = annotation.unwrap(...typeInstances);
+      return compareTypes(input, expected);
+    }
+    else if (input instanceof GenericType && (input.impl === impl || (impl && impl.isPrototypeOf(input.impl)))) {
       return 0;
     }
     else {
       return -1;
+    }
+  }
+
+  unwrap <P> (...typeInstances: Type<P>[]) {
+    const {context, impl} = this;
+    if (typeof impl !== 'function') {
+      return this;
+    }
+    const annotation = context.getAnnotation(impl);
+    if (annotation != null) {
+      return (annotation.unwrap(...typeInstances): any);
+    }
+    else {
+      return this;
     }
   }
 

--- a/packages/flow-runtime/src/types/ObjectType.js
+++ b/packages/flow-runtime/src/types/ObjectType.js
@@ -7,6 +7,8 @@ import ObjectTypeProperty from './ObjectTypeProperty';
 import ObjectTypeIndexer from './ObjectTypeIndexer';
 import ObjectTypeCallProperty from './ObjectTypeCallProperty';
 
+import {ClassDeclaration, ParameterizedClassDeclaration} from '../declarations';
+
 export type Property<K: string | number, V>
  = ObjectTypeProperty<K, V>
  | ObjectTypeIndexer<K, V>
@@ -164,14 +166,14 @@ export default class ObjectType<T: {}> extends Type {
   }
 
   compareWith (input: Type<any>): -1 | 0 | 1 {
-    if (!(input instanceof ObjectType)) {
+    if (!(input instanceof ObjectType || input instanceof ClassDeclaration || input instanceof ParameterizedClassDeclaration)) {
       return -1;
     }
     const hasCallProperties = this.callProperties.length > 0;
 
     let isGreater = false;
     if (hasCallProperties) {
-      const result = compareTypeCallProperties(this, input);
+      const result = compareTypeCallProperties(this, (input: $FlowFixme));
       if (result === -1) {
         return -1;
       }
@@ -182,10 +184,10 @@ export default class ObjectType<T: {}> extends Type {
 
     let result;
     if (this.indexers.length > 0) {
-      result = compareTypeWithIndexers(this, input);
+      result = compareTypeWithIndexers(this, (input: $FlowFixme));
     }
     else {
-      result = compareTypeWithoutIndexers(this, input);
+      result = compareTypeWithoutIndexers(this, (input: $FlowFixme));
     }
 
     if (result === -1) {
@@ -385,7 +387,7 @@ function compareTypeWithoutIndexers (type: ObjectType<any>, input: ObjectType<an
     for (let j = 0; j < inputProperties.length; j++) {
       const inputProperty = inputProperties[j];
       if (inputProperty.key === property.key) {
-        const result = compareTypes(property, inputProperty);
+        const result = compareTypes(property.value, inputProperty.value);
         if (result === -1) {
           return -1;
         }

--- a/packages/flow-runtime/src/types/TypeParameterApplication.js
+++ b/packages/flow-runtime/src/types/TypeParameterApplication.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import Type from './Type';
-import compareTypes from '../compareTypes';
 
 import type Validation, {ErrorTuple, IdentifierPath} from '../Validation';
 
@@ -29,7 +28,7 @@ export default class TypeParameterApplication<X, T> extends Type {
   }
 
   compareWith (input: Type<any>): -1 | 0 | 1 {
-    return compareTypes(this.parent, input);
+    return this.parent.compareWith(input, ...this.typeInstances);
   }
 
   hasProperty (name: string): boolean {
@@ -47,6 +46,10 @@ export default class TypeParameterApplication<X, T> extends Type {
     if (inner && typeof (inner: $FlowIgnore).getProperty === 'function') {
       return (inner: $FlowIgnore).getProperty(name, ...this.typeInstances);
     }
+  }
+
+  unwrap () {
+    return this.parent.unwrap(...this.typeInstances);
   }
 
   toString (): string {


### PR DESCRIPTION
Relaxes validation for `Class<T>` when `T` is a parameterized class. This was a total pain, and fixing this properly will require some refactoring. Fixes #79 