### PR TITLE
Only use a single copy of flow-runtime when other copies exist

### DIFF
--- a/packages/flow-runtime/src/globalContext.js
+++ b/packages/flow-runtime/src/globalContext.js
@@ -6,10 +6,19 @@ import registerTypePredicates from './registerTypePredicates';
 
 import TypeContext from './TypeContext';
 
-const globalContext = new TypeContext();
-registerPrimitiveTypes(globalContext);
-registerBuiltinTypeConstructors(globalContext);
-registerTypePredicates(globalContext);
+let globalContext;
+if (typeof global !== 'undefined' && typeof global.__FLOW_RUNTIME_GLOBAL_CONTEXT_DO_NOT_USE_THIS_VARIABLE__ !== 'undefined') {
+  globalContext = global.__FLOW_RUNTIME_GLOBAL_CONTEXT_DO_NOT_USE_THIS_VARIABLE__;
+}
+else {
+  globalContext = new TypeContext();
+  registerPrimitiveTypes(globalContext);
+  registerBuiltinTypeConstructors(globalContext);
+  registerTypePredicates(globalContext);
+  if (typeof global !== 'undefined') {
+    global.__FLOW_RUNTIME_GLOBAL_CONTEXT_DO_NOT_USE_THIS_VARIABLE__ = globalContext;
+  }
+}
 
 
 export default globalContext;


### PR DESCRIPTION
fixes #98 though i wonder if we should add a warning (might be annoying, and can't reasonably be configurable)