### PR TITLE
Nullable Properties

### DIFF
--- a/packages/flow-runtime/src/errorMessages.js
+++ b/packages/flow-runtime/src/errorMessages.js
@@ -27,6 +27,7 @@ const errorMessages = {
   ERR_EXPECT_THIS: 'must be exactly this',
   ERR_EXPECT_VOID: 'must be undefined',
   ERR_INVALID_DATE: 'must be a valid date',
+  ERR_MISSING_PROPERTY: 'does not exists on object',
   ERR_NO_INDEXER: 'is not one of the permitted indexer types',
   ERR_NO_UNION: 'must be one of: $0',
   ERR_UNKNOWN_KEY: 'should not contain the key: "$0"'

--- a/packages/flow-runtime/src/typed.test.js
+++ b/packages/flow-runtime/src/typed.test.js
@@ -70,6 +70,30 @@ describe('Typed API', () => {
     no(type.accepts(new A()));
   });
   
+  it('should assert nullable properties of an object', () => {
+    const type = t.object(t.property('foo', t.nullable(t.number())));
+    
+    const A = function A() {};
+    const B = function B() {};
+
+    ok(type.assert({foo: 0}));
+    ok(type.assert({foo: 1}));
+    ok(type.assert({foo: -1}));
+    ok(type.assert({foo: null}));
+    ok(type.assert({foo: undefined}));
+    throws(() => type.assert({foo: false}));
+    throws(() => type.assert({foo: ''}));
+    throws(() => type.assert());
+    throws(() => type.assert({}));
+    throws(() => type.assert(new B()));
+    A.foo = null;
+    throws(() => type.assert(new A()));
+    A.foo = undefined;
+    throws(() => type.assert(new A()));
+    A.foo = 1;
+    throws(() => type.assert(new A()));
+  });
+  
   it('should check nullable static properties of an object', () => {
     const type = t.object(t.staticProperty('foo', t.nullable(t.number())));
     
@@ -96,6 +120,34 @@ describe('Typed API', () => {
     no(type.accepts({foo: 1}));
     no(type.accepts());
     no(type.accepts({}));
+  });
+  
+  it('should assert nullable static properties of an object', () => {
+    const type = t.object(t.staticProperty('foo', t.nullable(t.number())));
+    
+    const A = function A() {};
+    const B = function B() {};
+
+    A.foo = null;
+    ok(type.assert(new A()));
+    A.foo = undefined;
+    ok(type.assert(new A()));
+    A.foo = 0;
+    ok(type.assert(new A()));
+    A.foo = 1;
+    ok(type.assert(new A()));
+    A.foo = -1;
+    ok(type.assert(new A()));
+    A.foo = false;
+    throws(() => type.assert(new A()));
+    A.foo = '';
+    throws(() => type.assert(new A()));
+    throws(() => type.assert(new B()));
+    throws(() => type.assert({foo: null}));
+    throws(() => type.assert({foo: undefined}));
+    throws(() => type.assert({foo: 1}));
+    throws(() => type.assert());
+    throws(() => type.assert({}));
   });
 
 

--- a/packages/flow-runtime/src/typed.test.js
+++ b/packages/flow-runtime/src/typed.test.js
@@ -45,6 +45,58 @@ describe('Typed API', () => {
     type.assert('');
     type.assert('foo');
   });
+  
+  it('should check nullable properties of an object', () => {
+    const type = t.object(t.property('foo', t.nullable(t.number())));
+    
+    const A = function A() {};
+    const B = function B() {};
+
+    ok(type.accepts({foo: 0}));
+    ok(type.accepts({foo: 1}));
+    ok(type.accepts({foo: -1}));
+    ok(type.accepts({foo: null}));
+    ok(type.accepts({foo: undefined}));
+    no(type.accepts({foo: false}));
+    no(type.accepts({foo: ''}));
+    no(type.accepts());
+    no(type.accepts({}));
+    no(type.accepts(new B()));
+    A.foo = null;
+    no(type.accepts(new A()));
+    A.foo = undefined;
+    no(type.accepts(new A()));
+    A.foo = 1;
+    no(type.accepts(new A()));
+  });
+  
+  it('should check nullable static properties of an object', () => {
+    const type = t.object(t.staticProperty('foo', t.nullable(t.number())));
+    
+    const A = function A() {};
+    const B = function B() {};
+
+    A.foo = null;
+    ok(type.accepts(new A()));
+    A.foo = undefined;
+    ok(type.accepts(new A()));
+    A.foo = 0;
+    ok(type.accepts(new A()));
+    A.foo = 1;
+    ok(type.accepts(new A()));
+    A.foo = -1;
+    ok(type.accepts(new A()));
+    A.foo = false;
+    no(type.accepts(new A()));
+    A.foo = '';
+    no(type.accepts(new A()));
+    no(type.accepts(new B()));
+    no(type.accepts({foo: null}));
+    no(type.accepts({foo: undefined}));
+    no(type.accepts({foo: 1}));
+    no(type.accepts());
+    no(type.accepts({}));
+  });
 
 
   it('should check a simple object with shortcut syntax', () => {

--- a/packages/flow-runtime/src/types/ObjectTypeProperty.js
+++ b/packages/flow-runtime/src/types/ObjectTypeProperty.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import Type from './Type';
+import NullableType from './NullableType';
 import compareTypes from '../compareTypes';
 import getErrorMessage from "../getErrorMessage";
 import {addConstraints, collectConstraintErrors, constraintsAccept} from '../typeConstraints';
@@ -76,11 +77,18 @@ export default class ObjectTypeProperty<K: string | number, V> extends Type {
     else {
       target = input[key];
     }
-
+    
     if (optional && target === undefined) {
       return true;
     }
-    else if (!value.accepts(target)) {
+    
+    if (value instanceof NullableType) {
+      if (key in (isStatic ? input.constructor : input) === false) {
+        return false;
+      }
+    }
+    
+    if (!value.accepts(target)) {
       return false;
     }
     else {


### PR DESCRIPTION
In case of `ObjectTypeProperty`'s value being `NullableType`, check if the property exists on the object or its prototype chain. See https://github.com/codemix/flow-runtime/issues/119