### PR TITLE
expose TypeSymbol

### DIFF
--- a/packages/flow-runtime/src/index.js
+++ b/packages/flow-runtime/src/index.js
@@ -3,7 +3,8 @@
 import globalContext from './globalContext';
 
 import {
-  TypeParametersSymbol
+  TypeParametersSymbol,
+  TypeSymbol
 } from './symbols';
 
 import AnyType from './types/AnyType';
@@ -115,5 +116,6 @@ export {
   ParameterizedClassDeclaration,
   ExtendsDeclaration,
 
-  TypeParametersSymbol
+  TypeParametersSymbol,
+  TypeSymbol
 };


### PR DESCRIPTION
Hey guys

exposing TypeSymbol makes it able for users of flow-runtime to access type annotations dynamically.

Right now I'm using something like this which is very ugly

```
function concat(a: string, b: string) : string {
  return a + b;
}
const symb = Object.getOwnPropertySymbols(concat)[0];
const annotation = concat[symb];
```

Also for some reason - es6 bundling probably - this doesn't work

```
import {TypeSymbol} from 'flow-runtime/lib/symbols';
const annotation = concat[TypeSymbol];
```