### PR TITLE
decorate -> annotate in example

### DIFF
--- a/packages/babel-plugin-flow-runtime/README.md
+++ b/packages/babel-plugin-flow-runtime/README.md
@@ -49,7 +49,7 @@ Next, add the following to your babel configuration or `.babelrc`:
 {
   "plugins": [["flow-runtime", {
     "assert": true,
-    "decorate": true
+    "annotate": true
   }]]
 }
 ```


### PR DESCRIPTION
Got this warning:

Warning: "decorate" option for babel-plugin-flow-runtime is now called "annotate", support for "decorate" will be removed in a future version.