### PR TITLE
Support alternative syntax for exact object

### DIFF
--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAliases/objects/objectWithExactIndexer.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/typeAliases/objects/objectWithExactIndexer.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+export const input = `
+  type Demo = {
+    foo?: number;
+    [any]: empty;
+  };
+`;
+
+export const expected = `
+  import t from "flow-runtime";
+  const Demo = t.type("Demo", t.exactObject(
+    t.property("foo", t.number(), true)
+  ));
+`;


### PR DESCRIPTION
When an exact object contains all optional fields, Flow doesn't support the `{||}` syntax. 

Example:
```javascript
type A = {| a?: string |};
const x: A = {} // error: object literal. Inexact type is incompatible with exact type
```

A common workaround is to use `{ [any]: empty }`, which also makes the object exact.

See:
- https://github.com/facebook/flow/issues/2977
- https://github.com/facebook/flow/issues/4582
  
This PR adds support for this style of writing an exact object. : )

FYI @phpnode 