### PR TITLE
Fix for missing validation of indexer input

### DIFF
--- a/packages/flow-runtime/src/__tests__/__fixtures__/bugs/186-object-type.js
+++ b/packages/flow-runtime/src/__tests__/__fixtures__/bugs/186-object-type.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import type TypeContext from "../../../TypeContext";
+
+function getSchemaType(t) {
+  const userIdType = t.type("UserId", t.string());
+  const userType = t.type("User", t.object(t.property("id", userIdType)));
+  return t.type(
+    "MySchema",
+    t.object(t.property("users", t.object(t.indexer("key", userIdType, userType))))
+  );
+}
+
+export function pass(t: TypeContext) {
+  return getSchemaType(t).assert({ users: { 'x': {id: 'x'} } });
+}
+
+export function fail(t: TypeContext) {
+  return getSchemaType(t).assert({ users: [] });
+}

--- a/packages/flow-runtime/src/types/ObjectType.js
+++ b/packages/flow-runtime/src/types/ObjectType.js
@@ -139,6 +139,10 @@ export default class ObjectType<T: {}> extends Type {
 
 
     if (this.indexers.length > 0) {
+      if (input instanceof Object && Array.isArray(input)) {
+        yield[path, getErrorMessage('ERR_EXPECT_OBJECT'), this];
+        return;
+      }
       yield* collectErrorsWithIndexers(this, validation, path, input);
     }
     else {


### PR DESCRIPTION
This fixes https://github.com/codemix/flow-runtime/issues/186

It seems the code tried to handle this, but in JavaScript `typeof [] === object`. 

Here I'm introducing https://lodash.com/docs/4.17.4#isPlainObject which is a very small utility that does correctly checks if something is a plain object, that is, an object created by the Object constructor or one with a `Prototype` of `null`.
