### PR TITLE
Update helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,11 @@ First clone the repo:
 git clone https://github.com/codemix/flow-runtime.git
 ```
 
-Now install `lerna` globally:
-
-```sh
-npm install --global lerna
-```
-
 And bootstrap the project:
 
 ```sh
 cd flow-runtime
-lerna bootstrap
-npm test
+yarn
+yarn bootstrap
+yarn test
 ```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "repository": "https://github.com/codemix/flow-runtime.git",
   "scripts": {
+    "clean": "rm -rf packages/*/node_modules packages/*/lib packages/*/dist packages/*/build node_modules *.log",
     "test": "lerna run test",
     "lint": "lerna run lint",
     "build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "test": "lerna run test",
     "lint": "lerna run lint",
     "build": "lerna run build",
+    "bootstrap": "lerna bootstrap",
     "ci": "lerna bootstrap && lerna run build && lerna run test"
   },
   "devDependencies": {


### PR DESCRIPTION
`lerna` is actually installed by the root package, so there is no need for people to install this globally.

Besides a `yarn run clean` command is convenient. 
