### PR TITLE
feat: attach validation errors to RuntimeTypeErrors

### DIFF
--- a/packages/flow-runtime/src/errorReporting/RuntimeTypeError.js
+++ b/packages/flow-runtime/src/errorReporting/RuntimeTypeError.js
@@ -1,5 +1,12 @@
 /* @flow */
 
+import type {ErrorTuple} from '../Validation';
+
 export default class RuntimeTypeError extends TypeError {
   name: string = "RuntimeTypeError";
+  errors: ?ErrorTuple[];
+  constructor(message: string, options?: {errors?: ErrorTuple[]}) {
+    super(message);
+    Object.assign(this, options);
+  }
 }

--- a/packages/flow-runtime/src/errorReporting/__tests__/makeTypeError.test.js
+++ b/packages/flow-runtime/src/errorReporting/__tests__/makeTypeError.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import {ok} from 'assert';
+import {ok, equal} from 'assert';
 
 import makeTypeError from '../makeTypeError';
 import t from '../../globalContext';
@@ -20,6 +20,14 @@ describe('makeTypeError', () => {
     const report = makeTypeError(validation);
     const err = report;
     ok(err instanceof TypeError);
+  });
+
+  it('should attach the validation errors to Error', () => {
+    const type = t.string();
+    const validation = t.validate(type, false);
+    const report = makeTypeError(validation);
+    const err = report;
+    equal(err.errors, validation.errors);
   });
 
   describe('Objects', () => {

--- a/packages/flow-runtime/src/errorReporting/makeTypeError.js
+++ b/packages/flow-runtime/src/errorReporting/makeTypeError.js
@@ -11,9 +11,9 @@ export default function makeTypeError <T> (validation: Validation<T>) {
   if (!validation.hasErrors()) {
     return;
   }
-  const {prefix, input, context} = validation;
+  const {prefix, input, context, errors} = validation;
   const collected = [];
-  for (const [path, message, expectedType] of validation.errors) {
+  for (const [path, message, expectedType] of errors) {
     const expected = expectedType ? expectedType.toString() : "*";
     const actual = resolvePath(input, path);
     const actualType = context.typeOf(actual).toString();
@@ -31,10 +31,10 @@ export default function makeTypeError <T> (validation: Validation<T>) {
     }
   }
   if (prefix) {
-    return new RuntimeTypeError(`${prefix.trim()} ${collected.join(delimiter)}`);
+    return new RuntimeTypeError(`${prefix.trim()} ${collected.join(delimiter)}`, {errors});
   }
   else {
-    return new RuntimeTypeError(collected.join(delimiter));
+    return new RuntimeTypeError(collected.join(delimiter), {errors});
   }
 }
 


### PR DESCRIPTION
With this, all `RuntimeTypeError`s thrown by assertions will have an `errors` property with the same `ErrorTuple`s as the `Validation` did.

I was surprised that the errors thrown don't include any metadata.  It would be convenient to have.

Notes:
* No breaking changes -- user code can still construct `RuntimeTypeError`s without including any `errors`
* I'm putting the `errors` from validation straight into the errors thrown.  Maybe it would be less risky to clone it? 