### PR TITLE
Add moduleName to options of babel-plugin

### DIFF
--- a/packages/babel-plugin-flow-runtime/README.md
+++ b/packages/babel-plugin-flow-runtime/README.md
@@ -60,7 +60,7 @@ The plugin supports the following options:
 
 - `assert` - Boolean, indicates whether types should be asserted at runtime. Defaults to `true` if `process.env.NODE_ENV === 'development'`, otherwise `false`.
 - `annotate` - Boolean, indicates whether object or function values that have type annotations should be decorated with those types at runtime. Defaults to `true`.
-- `flowRuntimePath` - String, indicates which runtime to use. Defaults to `flow-runtime`
+- `libraryName` - String, indicates which runtime to use. Defaults to `flow-runtime`
 
 
 If `assert` is `true`, the following code:

--- a/packages/babel-plugin-flow-runtime/README.md
+++ b/packages/babel-plugin-flow-runtime/README.md
@@ -60,7 +60,7 @@ The plugin supports the following options:
 
 - `assert` - Boolean, indicates whether types should be asserted at runtime. Defaults to `true` if `process.env.NODE_ENV === 'development'`, otherwise `false`.
 - `annotate` - Boolean, indicates whether object or function values that have type annotations should be decorated with those types at runtime. Defaults to `true`.
-- `moduleName` - String, indicates which runtime to use. Defaults to `flow-runtime`
+- `flowRuntimePath` - String, indicates which runtime to use. Defaults to `flow-runtime`
 
 
 If `assert` is `true`, the following code:

--- a/packages/babel-plugin-flow-runtime/README.md
+++ b/packages/babel-plugin-flow-runtime/README.md
@@ -60,6 +60,7 @@ The plugin supports the following options:
 
 - `assert` - Boolean, indicates whether types should be asserted at runtime. Defaults to `true` if `process.env.NODE_ENV === 'development'`, otherwise `false`.
 - `annotate` - Boolean, indicates whether object or function values that have type annotations should be decorated with those types at runtime. Defaults to `true`.
+- `moduleName` - String, indicates which runtime to use. Defaults to `flow-runtime`
 
 
 If `assert` is `true`, the following code:

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
@@ -10,3 +10,9 @@ export const expected = `
   import _t from "flow-runtime";
   const Demo = _t.type("Demo", _t.number());
 `;
+
+export const customRuntime = `
+  import t from "babel-types";
+  import _t from "./custom-flow-runtime";
+  const Demo = _t.type("Demo", _t.number());
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntime.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntime.js
@@ -9,3 +9,8 @@ export const expected = `
   import types from "flow-runtime";
   const Demo = types.type("Demo", types.number());
 `;
+
+export const customRuntime = `
+  import types from "flow-runtime";
+  const Demo = types.type("Demo", types.number());
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReify.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReify.js
@@ -14,3 +14,11 @@ export const expected = `
   const Demo = rt.type("Demo", rt.number());
   console.log(Demo);
 `;
+
+export const customRuntime = `
+  import rt, { reify } from "flow-runtime";
+  import { Type as _Type } from "flow-runtime";
+  const Type = rt.tdz(() => _Type);
+  const Demo = rt.type("Demo", rt.number());
+  console.log(Demo);
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReifyNoDefault.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importFlowRuntimeReifyNoDefault.js
@@ -15,3 +15,12 @@ export const expected = `
   const Demo = t.type("Demo", t.number());
   console.log(Demo);
 `;
+
+export const customRuntime = `
+  import { reify } from "flow-runtime";
+  import { Type as _Type } from "flow-runtime";
+  import t from "./custom-flow-runtime";
+  const Type = t.tdz(() => _Type);
+  const Demo = t.type("Demo", t.number());
+  console.log(Demo);
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/shorthandImportType.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/shorthandImportType.js
@@ -23,3 +23,16 @@ export const expected = `
     t.property("value", t.ref(Demo))
   ));
 `;
+
+export const customRuntime = `
+  import { Demo as _Demo } from './simplestExportType';
+  import t from "./custom-flow-runtime";
+  const Demo = t.tdz(() => _Demo);
+
+  const Local = t.type("Local", t.number());
+
+  const Item = t.type("Item", t.object(
+    t.property("local", Local),
+    t.property("value", t.ref(Demo))
+  ));
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestExportType.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestExportType.js
@@ -8,3 +8,8 @@ export const expected = `
   import t from "flow-runtime";
   export const Demo = t.type("Demo", t.string());
 `;
+
+export const customRuntime = `
+  import t from "./custom-flow-runtime";
+  export const Demo = t.type("Demo", t.string());
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestImportType.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/simplestImportType.js
@@ -23,3 +23,16 @@ export const expected = `
     t.property("value", t.ref(Demo))
   ));
 `;
+
+export const customRuntime = `
+  import { Demo as _Demo } from './simplestExportType';
+  import t from "./custom-flow-runtime";
+  const Demo = t.tdz(() => _Demo);
+
+  const Local = t.type("Local", t.number());
+
+  const Item = t.type("Item", t.object(
+    t.property("local", Local),
+    t.property("value", t.ref(Demo))
+  ));
+`;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/fixtures.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/fixtures.js
@@ -42,6 +42,7 @@ export type Fixture = {
   expected: string;
   annotated?: string;
   combined?: string;
+  customRuntime?: string;
 };
 
 const fixtures: Map<string, Fixture> = new Map(files.filter(filterIncluded).map(filename => {

--- a/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
@@ -5,7 +5,7 @@ import fixtures from './fixtures';
 import testTransform from './testTransform';
 
 describe('transform', () => {
-  for (const [name, {input, expected, annotated, combined}] of fixtures) {
+  for (const [name, {input, expected, annotated, combined, customRuntime}] of fixtures) {
     it(`should transform ${name}`, () => {
       testTransform(input, {assert: true, annotate: false}, expected);
     });
@@ -17,6 +17,11 @@ describe('transform', () => {
     if (combined) {
       it(`should transform ${name} with decorations and assertions`, () => {
         testTransform(input, {assert: true, annotate: true}, combined);
+      });
+    }
+    if (customRuntime) {
+      it(`should transform ${name} with custom runtime path`, () => {
+        testTransform(input, {flowRuntimePath: './custom-flow-runtime'}, customRuntime);
       });
     }
   }

--- a/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/transform.test.js
@@ -21,7 +21,7 @@ describe('transform', () => {
     }
     if (customRuntime) {
       it(`should transform ${name} with custom runtime path`, () => {
-        testTransform(input, {flowRuntimePath: './custom-flow-runtime'}, customRuntime);
+        testTransform(input, {libraryName: './custom-flow-runtime'}, customRuntime);
       });
     }
   }

--- a/packages/babel-plugin-flow-runtime/src/createConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/createConversionContext.js
@@ -11,15 +11,15 @@ export type Options = {
   suppressTypes?: string[];
   // deprecated
   decorate?: boolean;
-  moduleName?: string,
+  flowRuntimePath?: string,
 };
 
 export default function createConversionContext (options: Options): ConversionContext {
 
   const context = new ConversionContext();
 
-  if (options.moduleName) {
-    context.libraryName = options.moduleName
+  if (options.flowRuntimePath) {
+    context.libraryName = options.flowRuntimePath
   }
 
   context.optInOnly = options.optInOnly ? true : false;

--- a/packages/babel-plugin-flow-runtime/src/createConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/createConversionContext.js
@@ -19,7 +19,7 @@ export default function createConversionContext (options: Options): ConversionCo
   const context = new ConversionContext();
 
   if (options.flowRuntimePath) {
-    context.libraryName = options.flowRuntimePath
+    context.libraryName = options.flowRuntimePath;
   }
 
   context.optInOnly = options.optInOnly ? true : false;

--- a/packages/babel-plugin-flow-runtime/src/createConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/createConversionContext.js
@@ -11,15 +11,15 @@ export type Options = {
   suppressTypes?: string[];
   // deprecated
   decorate?: boolean;
-  flowRuntimePath?: string,
+  libraryName?: string,
 };
 
 export default function createConversionContext (options: Options): ConversionContext {
 
   const context = new ConversionContext();
 
-  if (options.flowRuntimePath) {
-    context.libraryName = options.flowRuntimePath;
+  if (options.libraryName) {
+    context.libraryName = options.libraryName;
   }
 
   context.optInOnly = options.optInOnly ? true : false;

--- a/packages/babel-plugin-flow-runtime/src/createConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/createConversionContext.js
@@ -11,11 +11,16 @@ export type Options = {
   suppressTypes?: string[];
   // deprecated
   decorate?: boolean;
+  moduleName?: string,
 };
 
 export default function createConversionContext (options: Options): ConversionContext {
 
   const context = new ConversionContext();
+
+  if (options.moduleName) {
+    context.libraryName = options.moduleName
+  }
 
   context.optInOnly = options.optInOnly ? true : false;
 
@@ -37,14 +42,14 @@ export default function createConversionContext (options: Options): ConversionCo
                          ? true
                          : Boolean(options.annotate)
                          ;
-  
+
   if ('suppressComments' in options && Array.isArray(options.suppressComments)) {
     context.suppressCommentPatterns = options.suppressComments.map(regexString => new RegExp(regexString));
   }
-  
+
   if ('suppressTypes' in options && Array.isArray(options.suppressTypes)) {
     context.suppressTypeNames = options.suppressTypes;
   }
-  
+
   return context;
 }

--- a/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
@@ -278,4 +278,3 @@ function ensureConstructor (path: NodePath) {
     path.get('body').unshiftContainer('body', constructorNode);
   }
 }
-

--- a/packages/babel-plugin-flow-runtime/src/index.js
+++ b/packages/babel-plugin-flow-runtime/src/index.js
@@ -51,4 +51,3 @@ export {
   findIdentifiers,
   getTypeParameters
 };
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -7338,9 +7338,9 @@ ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
-uglify-js@3.1.x:
+uglify-js@3.1.x, "uglify-js@git://github.com/mishoo/UglifyJS2.git#harmony":
   version "3.1.9"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.1.9.tgz#dffca799308cf327ec3ac77eeacb8e196ce3b452"
+  resolved "git://github.com/mishoo/UglifyJS2.git#9632f79e4692b3055ea3bb2580bca6f6a0412f7b"
   dependencies:
     commander "~2.11.0"
     source-map "~0.6.1"
@@ -7353,13 +7353,6 @@ uglify-js@^2.6, uglify-js@^2.6.1:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
-
-"uglify-js@git://github.com/mishoo/UglifyJS2.git#harmony":
-  version "3.1.9"
-  resolved "git://github.com/mishoo/UglifyJS2.git#9632f79e4692b3055ea3bb2580bca6f6a0412f7b"
-  dependencies:
-    commander "~2.11.0"
-    source-map "~0.6.1"
 
 uglify-js@~2.7.3:
   version "2.7.5"


### PR DESCRIPTION
This option is useful for a fork or when you use a monorepo and node is not resolving the path correctly.