### PR TITLE
Babel 7 compatibility

### DIFF
--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@vjpr/babel-plugin-flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
-  "version": "0.17.0",
+  "version": "0.17.0-vjpr.1",
   "description": "Transforms flow type annotations into flow-runtime types, optionally adds runtime type validation to annotated code.",
   "main": "babel-plugin-flow-runtime.js",
   "scripts": {

--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0-beta.52",
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
@@ -38,9 +39,9 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "babel-generator": "^6.21.0",
-    "babel-traverse": "^6.20.0",
-    "babel-types": "^6.16.0",
+    "@babel/generator": "^7.0.0-beta.52",
+    "@babel/traverse": "^7.0.0-beta.52",
+    "@babel/types": "^7.0.0-beta.52",
     "babylon": "^6.16.1",
     "camelcase": "^3.0.0",
     "flow-config-parser": "^0.3.0"

--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@vjpr/babel-plugin-flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
-  "version": "0.17.0-vjpr.1",
+  "version": "0.17.0-vjpr.2",
   "description": "Transforms flow type annotations into flow-runtime types, optionally adds runtime type validation to annotated code.",
   "main": "babel-plugin-flow-runtime.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@babel/helper-plugin-utils": "^7.0.0-beta.52",
+    "@babel/helper-plugin-utils": "7.0.0-rc.1",
     "babel-cli": "^6.16.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.0.0",
@@ -39,9 +39,9 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "@babel/generator": "^7.0.0-beta.52",
-    "@babel/traverse": "^7.0.0-beta.52",
-    "@babel/types": "^7.0.0-beta.52",
+    "@babel/generator": "7.0.0-rc.1",
+    "@babel/traverse": "7.0.0-rc.1",
+    "@babel/types": "7.0.0-rc.1",
     "babylon": "^6.16.1",
     "camelcase": "^3.0.0",
     "flow-config-parser": "^0.3.0"

--- a/packages/babel-plugin-flow-runtime/package.json
+++ b/packages/babel-plugin-flow-runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-plugin-flow-runtime",
+  "name": "@vjpr/babel-plugin-flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
   "version": "0.17.0",

--- a/packages/babel-plugin-flow-runtime/src/ConversionContext.js
+++ b/packages/babel-plugin-flow-runtime/src/ConversionContext.js
@@ -1,10 +1,10 @@
 /* @flow */
 
 
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 import Entity from './Entity';
 import type {EntityType} from './Entity';
-import type {Node, NodePath} from 'babel-traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 
 const tdzIdentifiers: WeakSet<Node> = new WeakSet();

--- a/packages/babel-plugin-flow-runtime/src/Entity.js
+++ b/packages/babel-plugin-flow-runtime/src/Entity.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {Node, NodePath, Scope} from 'babel-traverse';
+import type {Node, NodePath, Scope} from '@babel/traverse';
 
 
 export type EntityType

--- a/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/__fixtures__/importsExports/importClashName.js
@@ -1,18 +1,18 @@
 /* @flow */
 
 export const input = `
-  import t from "babel-types";
+  import t from "@babel/types";
   type Demo = number;
 `;
 
 export const expected = `
-  import t from "babel-types";
+  import t from "@babel/types";
   import _t from "flow-runtime";
   const Demo = _t.type("Demo", _t.number());
 `;
 
 export const customRuntime = `
-  import t from "babel-types";
+  import t from "@babel/types";
   import _t from "./custom-flow-runtime";
   const Demo = _t.type("Demo", _t.number());
 `;

--- a/packages/babel-plugin-flow-runtime/src/__tests__/testTransform.js
+++ b/packages/babel-plugin-flow-runtime/src/__tests__/testTransform.js
@@ -7,9 +7,9 @@ import fixtures from './fixtures';
 import transform from '../transform';
 
 import * as babylon from 'babylon';
-import generate from 'babel-generator';
-import traverse from 'babel-traverse';
-import type {Node, NodePath} from 'babel-traverse';
+import generate from '@babel/generator';
+import traverse from '@babel/traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 import type {Options} from '../createConversionContext';
 

--- a/packages/babel-plugin-flow-runtime/src/annotateVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/annotateVisitors.js
@@ -1,10 +1,10 @@
 /* @flow */
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
 import type ConversionContext from './ConversionContext';
 import convert from './convert';
 
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 import hasTypeAnnotations from './hasTypeAnnotations';
 

--- a/packages/babel-plugin-flow-runtime/src/annotateVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/annotateVisitors.js
@@ -63,6 +63,7 @@ export default function annotateVisitors (context: ConversionContext): Object {
         else if (path.isFunctionDeclaration() && path.parentPath.isExportDefaultDeclaration()) {
           // @fixme - this is not nice, we just turn the declaration into an expression.
           path.node.type = 'FunctionExpression';
+          // TODO(vjpr): BABEL7: https://babeljs.io/docs/en/next/v7-migration-api#expression-field-removed-from-arrowfunctionexpression
           path.node.expression = true;
           const replacement = t.exportDefaultDeclaration(
             context.call(

--- a/packages/babel-plugin-flow-runtime/src/attachImport.js
+++ b/packages/babel-plugin-flow-runtime/src/attachImport.js
@@ -1,8 +1,8 @@
 /* @flow */
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
 import type ConversionContext from './ConversionContext';
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 export default function attachImport (context: ConversionContext, program: NodePath) {
 

--- a/packages/babel-plugin-flow-runtime/src/collectProgramOptions.js
+++ b/packages/babel-plugin-flow-runtime/src/collectProgramOptions.js
@@ -1,6 +1,6 @@
 /* @flow */
-import * as t from 'babel-types';
-import type {Node} from 'babel-traverse';
+import * as t from '@babel/types';
+import type {Node} from '@babel/traverse';
 
 import type ConversionContext from './ConversionContext';
 import type {Options} from './createConversionContext';

--- a/packages/babel-plugin-flow-runtime/src/convert.js
+++ b/packages/babel-plugin-flow-runtime/src/convert.js
@@ -1,11 +1,11 @@
 /* @flow */
 
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
 import getTypeParameters from './getTypeParameters';
 import typeAnnotationIterator from './typeAnnotationIterator';
 
-import type {Node, NodePath} from 'babel-traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 import type ConversionContext from './ConversionContext';
 

--- a/packages/babel-plugin-flow-runtime/src/convert.js
+++ b/packages/babel-plugin-flow-runtime/src/convert.js
@@ -211,7 +211,7 @@ function annotationToValue (context: ConversionContext, subject: NodePath): Node
       return t.identifier('undefined');
     case 'BooleanLiteralTypeAnnotation':
       return t.booleanLiteral(subject.node.value);
-    case 'NumericLiteralTypeAnnotation':
+    case 'NumberLiteralTypeAnnotation':
       return t.numericLiteral(subject.node.value);
     case 'StringLiteralTypeAnnotation':
       return t.stringLiteral(subject.node.value);
@@ -527,9 +527,10 @@ converters.NumberTypeAnnotation = (context: ConversionContext, {node}: NodePath)
   return context.call('number');
 };
 
-converters.NumericLiteralTypeAnnotation = (context: ConversionContext, {node}: NodePath): Node => {
-  return context.call('number', t.numericLiteral(node.value));
-};
+// BABEL7
+//converters.NumericLiteralTypeAnnotation = (context: ConversionContext, {node}: NodePath): Node => {
+//  return context.call('number', t.numericLiteral(node.value));
+//};
 
 // Duplicated for compatibility with flow-parser.
 converters.NumberLiteralTypeAnnotation = (context: ConversionContext, {node}: NodePath): Node => {

--- a/packages/babel-plugin-flow-runtime/src/findIdentifiers.js
+++ b/packages/babel-plugin-flow-runtime/src/findIdentifiers.js
@@ -1,5 +1,5 @@
 /* @flow */
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 export default function findIdentifiers (path: NodePath | NodePath[], found: NodePath[] = []): NodePath[] {
   if (Array.isArray(path)) {

--- a/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
@@ -132,6 +132,7 @@ export default function firstPassVisitors (context: ConversionContext): Object {
             t.returnStatement(body.node)
           ]));
           body = path.get('body');
+          // BABEL7
           path.node.expression = false;
         }
 

--- a/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/firstPassVisitors.js
@@ -1,6 +1,6 @@
 /* @flow */
-import * as t from 'babel-types';
-import type {NodePath} from 'babel-traverse';
+import * as t from '@babel/types';
+import type {NodePath} from '@babel/traverse';
 
 import attachImport from './attachImport';
 import getTypeParameters from './getTypeParameters';

--- a/packages/babel-plugin-flow-runtime/src/getTypeParameters.js
+++ b/packages/babel-plugin-flow-runtime/src/getTypeParameters.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 /**
  * Get an array of type parameters from the given path.

--- a/packages/babel-plugin-flow-runtime/src/hasTypeAnnotations.js
+++ b/packages/babel-plugin-flow-runtime/src/hasTypeAnnotations.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 
 export default function hasTypeAnnotations (path: NodePath): boolean {

--- a/packages/babel-plugin-flow-runtime/src/index.js
+++ b/packages/babel-plugin-flow-runtime/src/index.js
@@ -9,7 +9,7 @@ import annotateVisitors from './annotateVisitors';
 import patternMatchVisitors from './patternMatchVisitors';
 import preTransformVisitors from './preTransformVisitors';
 import transformVisitors from './transformVisitors';
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 import transform from './transform';
 import findIdentifiers from './findIdentifiers';

--- a/packages/babel-plugin-flow-runtime/src/index.js
+++ b/packages/babel-plugin-flow-runtime/src/index.js
@@ -15,11 +15,24 @@ import transform from './transform';
 import findIdentifiers from './findIdentifiers';
 import getTypeParameters from './getTypeParameters';
 
-export default function babelPluginFlowRuntime () {
+import generate from '@babel/generator'
+
+export default function babelPluginFlowRuntime (api, opts, dirname) {
+  console.log('running babel-plugin-flow-runtime:', {opts, dirname})
+
   return {
     visitor: {
+
       Program (path: NodePath, state: Object) {
         const {opts} = state;
+
+        // Plugins will appear multiple times if using overrides.
+        //console.log('---')
+        //console.log(state.file.opts.filename)
+        //console.log(state.file.opts.plugins.map(k => k.key))
+        //console.log(state.file.opts.test)
+        //console.log(state)
+
         const context = createConversionContext(opts || {});
         if (!collectProgramOptions(context, path.node)) {
           return;
@@ -32,6 +45,7 @@ export default function babelPluginFlowRuntime () {
           attachImport(context, path);
         }
         path.traverse(patternMatchVisitors(context));
+
         if (context.shouldAnnotate) {
           context.isAnnotating = true;
           path.traverse(annotateVisitors(context));
@@ -40,6 +54,12 @@ export default function babelPluginFlowRuntime () {
         }
         path.traverse(preTransformVisitors(context));
         path.traverse(transformVisitors(context));
+
+        // DEBUG: Print result.
+        //console.log(generate(path.node).code)
+        //console.log('---------------------------------------------------------------------------')
+        // --
+
       }
     }
   };

--- a/packages/babel-plugin-flow-runtime/src/index.js
+++ b/packages/babel-plugin-flow-runtime/src/index.js
@@ -18,7 +18,7 @@ import getTypeParameters from './getTypeParameters';
 import generate from '@babel/generator'
 
 export default function babelPluginFlowRuntime (api, opts, dirname) {
-  console.log('running babel-plugin-flow-runtime:', {opts, dirname})
+  //console.log('running babel-plugin-flow-runtime:', {opts, dirname})
 
   return {
     visitor: {

--- a/packages/babel-plugin-flow-runtime/src/index.js
+++ b/packages/babel-plugin-flow-runtime/src/index.js
@@ -26,6 +26,9 @@ export default function babelPluginFlowRuntime (api, opts, dirname) {
       Program (path: NodePath, state: Object) {
         const {opts} = state;
 
+        //console.log('start flow-runtime transpile', state.file.opts.filename)
+        //console.time(state.file.opts.filename)
+
         // Plugins will appear multiple times if using overrides.
         //console.log('---')
         //console.log(state.file.opts.filename)
@@ -59,6 +62,7 @@ export default function babelPluginFlowRuntime (api, opts, dirname) {
         //console.log(generate(path.node).code)
         //console.log('---------------------------------------------------------------------------')
         // --
+        //console.timeEnd(state.file.opts.filename)
 
       }
     }

--- a/packages/babel-plugin-flow-runtime/src/patternMatchVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/patternMatchVisitors.js
@@ -1,12 +1,12 @@
 /* @flow */
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
-import generate from 'babel-generator';
+import generate from '@babel/generator';
 
 import type ConversionContext from './ConversionContext';
 import convert from './convert';
 
-import type {Node, NodePath} from 'babel-traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 type SimplifiedParam = {
   path: NodePath;

--- a/packages/babel-plugin-flow-runtime/src/patternMatchVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/patternMatchVisitors.js
@@ -399,7 +399,7 @@ function inlineTest (context: ConversionContext, typeAnnotation: NodePath, repla
       t.stringLiteral(typeAnnotation.node.value)
     );
   }
-  else if (typeAnnotation.isNumericLiteralTypeAnnotation()) {
+  else if (typeAnnotation.isNumberLiteralTypeAnnotation()) {
     return t.binaryExpression(
       '===',
       replacement,

--- a/packages/babel-plugin-flow-runtime/src/preTransformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/preTransformVisitors.js
@@ -1,6 +1,6 @@
 /* @flow */
-import * as t from 'babel-types';
-import type {NodePath} from 'babel-traverse';
+import * as t from '@babel/types';
+import type {NodePath} from '@babel/traverse';
 import type ConversionContext from './ConversionContext';
 
 

--- a/packages/babel-plugin-flow-runtime/src/preTransformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/preTransformVisitors.js
@@ -97,7 +97,7 @@ function foldComplexParamsIntoBody (path: NodePath) {
 function isSimple (path: NodePath): boolean {
   switch (path.type) {
     case 'NullLiteral':
-    case 'NumericLiteral':
+    case 'NumberLiteral':
     case 'StringLiteral':
     case 'BooleanLiteral':
     case 'RegExpLiteral':

--- a/packages/babel-plugin-flow-runtime/src/transform.js
+++ b/packages/babel-plugin-flow-runtime/src/transform.js
@@ -1,5 +1,5 @@
 /* @flow */
-import traverse from 'babel-traverse';
+import traverse from '@babel/traverse';
 
 import collectProgramOptions from './collectProgramOptions';
 import firstPassVisitors from './firstPassVisitors';
@@ -7,7 +7,7 @@ import patternMatchVisitors from './patternMatchVisitors';
 import annotateVisitors from './annotateVisitors';
 import preTransformVisitors from './preTransformVisitors';
 import transformVisitors from './transformVisitors';
-import type {Node, NodePath} from 'babel-traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 import createConversionContext from './createConversionContext';
 import type {Options} from './createConversionContext';

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -278,6 +278,16 @@ export default function transformVisitors (context: ConversionContext): Object {
           convert(context, id.get('typeAnnotation')),
           path.get('init').node
         );
+
+        // DEBUG: Print out before/after replacement.
+        //console.log(require('@babel/generator').default(path.node))
+        //console.log(require('@babel/generator').default(t.variableDeclarator(
+        //  t.identifier(name),
+        //  wrapped
+        //)))
+
+        // vjpr: We remove the scope.
+        path.scope.removeOwnBinding(name)
         context.replacePath(path, t.variableDeclarator(
           t.identifier(name),
           wrapped
@@ -308,6 +318,13 @@ export default function transformVisitors (context: ConversionContext): Object {
       ));
     },
     Function (path: NodePath) {
+
+      //const c = require('chalk')
+      //console.log(c.grey(require('@babel/generator').default(path.node).code))
+      //console.log(context.visited.has(path.node))
+      //console.log(context.visited)
+      //console.log('---')
+
       if (context.shouldSuppressPath(path)) {
         path.skip();
         return;

--- a/packages/babel-plugin-flow-runtime/src/transformVisitors.js
+++ b/packages/babel-plugin-flow-runtime/src/transformVisitors.js
@@ -1,5 +1,5 @@
 /* @flow */
-import * as t from 'babel-types';
+import * as t from '@babel/types';
 
 import typeAnnotationIterator from './typeAnnotationIterator';
 import type ConversionContext from './ConversionContext';
@@ -7,7 +7,7 @@ import convert from './convert';
 
 import getTypeParameters from './getTypeParameters';
 import {ok as invariant} from 'assert';
-import type {Node, NodePath} from 'babel-traverse';
+import type {Node, NodePath} from '@babel/traverse';
 
 
 export default function transformVisitors (context: ConversionContext): Object {

--- a/packages/babel-plugin-flow-runtime/src/typeAnnotationIterator.js
+++ b/packages/babel-plugin-flow-runtime/src/typeAnnotationIterator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import type {NodePath} from 'babel-traverse';
+import type {NodePath} from '@babel/traverse';
 
 const visitors = {
   ArrayTypeAnnotation: ["elementType"],

--- a/packages/flow-runtime/package.json
+++ b/packages/flow-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@vjpr/flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
-  "version": "0.17.0",
+  "version": "0.17.0-vjpr.1",
   "description": "A flow compatible type system for JS.",
   "main": "dist/flow-runtime.js",
   "module": "dist/flow-runtime.es2015.js",

--- a/packages/flow-runtime/package.json
+++ b/packages/flow-runtime/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flow-runtime",
+  "name": "@vjpr/flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
   "version": "0.17.0",
@@ -51,5 +51,8 @@
   },
   "eslintConfig": {
     "extends": "./config/eslint.js"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.0.0-beta.52"
   }
 }

--- a/packages/flow-runtime/package.json
+++ b/packages/flow-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@vjpr/flow-runtime",
   "homepage": "https://codemix.github.io/flow-runtime",
   "repository": "https://github.com/codemix/flow-runtime.git",
-  "version": "0.17.0-vjpr.1",
+  "version": "0.17.0-vjpr.2",
   "description": "A flow compatible type system for JS.",
   "main": "dist/flow-runtime.js",
   "module": "dist/flow-runtime.es2015.js",
@@ -53,6 +53,6 @@
     "extends": "./config/eslint.js"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.52"
+    "@babel/runtime": "^7.0.0-rc.1"
   }
 }


### PR DESCRIPTION
- Rename all usages for `babel-*` dependencies with `@babel/*`
- Remove babel@6 deps and added babel@7 deps
- Fix a scope issue: https://github.com/codemix/flow-runtime/issues/184#issuecomment-403667277

Babel 6 still used for compiling itself.

Not ready for merging, still contains stray commented-out debugging, etc.